### PR TITLE
Design: 게시글 카테고리 요소 추가 / Member, Post 명시적 삭제 컬럼 추가

### DIFF
--- a/src/main/java/piglin/swapswap/domain/member/entity/Member.java
+++ b/src/main/java/piglin/swapswap/domain/member/entity/Member.java
@@ -40,6 +40,9 @@ public class Member {
     @Column(nullable = false, length = 10)
     private UserRoleEnum role;
 
+    @Column(nullable = false)
+    private Boolean isDeleted;
+
     @OneToMany(mappedBy = "member")
     private List<Post> postList;
 

--- a/src/main/java/piglin/swapswap/domain/post/constant/Category.java
+++ b/src/main/java/piglin/swapswap/domain/post/constant/Category.java
@@ -1,5 +1,62 @@
 package piglin.swapswap.domain.post.constant;
 
+import lombok.Getter;
+
+@Getter
 public enum Category {
 
+    HOME_ELECTRONICS(CategoryName.HOME_ELECTRONICS),
+
+    ELECTRONICS(CategoryName.ELECTRONICS),
+
+    FASHION_MISCELLANEOUS(CategoryName.FASHION_MISCELLANEOUS),
+
+    BEAUTY(CategoryName.BEAUTY),
+
+    INFANT_CHILDCARE(CategoryName.INFANT_CHILDCARE),
+
+    FOOD(CategoryName.FOOD),
+
+    KITCHEN(CategoryName.KITCHEN),
+
+    HOUSEHOLD(CategoryName.HOUSEHOLD),
+
+    FURNITURE_INTERIOR(CategoryName.FURNITURE_INTERIOR),
+
+    SPORT_LEISURE(CategoryName.SPORT_LEISURE),
+
+    CAR(CategoryName.CAR),
+
+    HOBBY_GAME_BOOK_ALBUM_DVD(CategoryName.HOBBY_GAME_BOOK_ALBUM_DVD),
+
+    OFFICE_SUPPLIES(CategoryName.OFFICE_SUPPLIES),
+
+    PET(CategoryName.PET),
+
+    ETC(CategoryName.ETC);
+
+    private final String name;
+
+    Category(String name) {
+        this.name = name;
+    }
+
+    public static class CategoryName {
+
+        public static final String HOME_ELECTRONICS = "가전제품";
+        public static final String ELECTRONICS = "전자제품";
+        public static final String FASHION_MISCELLANEOUS = "패션의류/잡화";
+        public static final String BEAUTY = "뷰티/미용";
+        public static final String INFANT_CHILDCARE = "출산/유아동";
+        public static final String FOOD = "식품";
+        public static final String KITCHEN = "주방용품";
+        public static final String HOUSEHOLD = "생활용품";
+        public static final String FURNITURE_INTERIOR = "가구/인테리어";
+        public static final String SPORT_LEISURE = "스포츠/레저";
+        public static final String CAR = "자동차용품";
+        public static final String HOBBY_GAME_BOOK_ALBUM_DVD = "취미/게임/도서/음반/DVD";
+        public static final String OFFICE_SUPPLIES = "문구/오피스";
+        public static final String PET = "반려동물용품";
+        public static final String ETC = "기타중고물품";
+    }
 }

--- a/src/main/java/piglin/swapswap/domain/post/entity/Post.java
+++ b/src/main/java/piglin/swapswap/domain/post/entity/Post.java
@@ -49,6 +49,9 @@ public class Post extends BaseTime {
     @Column(nullable = false)
     private Long upCnt;
 
+    @Column(nullable = false)
+    private Boolean isDeleted;
+
     @ManyToOne
     @JoinColumn(name = "member_id")
     private Member member;


### PR DESCRIPTION
## 📝 개요
- DB 테이블 생성 시 게시글 테이블 생성 오류가 생겨서 카테고리 enum 타입에 요소를 추가했습니다.
- 중요한 데이터인 Member, Post 에 명시적 삭제 컬럼이 존재 하지 않았습니다
<br>

## 👨‍💻 작업 내용
- Category enum 클래스에 제품 타입별 분류하고 추가했습니다.
- Member, Post 에 명시적 삭제 컬럼을 추가 했습니다.
<br>

## 🙇🏻‍♂️ 리뷰어에게
- 저장 시 값을 한글로 저장되게 했습니다 ! 영어로 할까 한글로 할까 고민했는데 한글로 하는 게 나을 거 같았습니다
<br>
