### PR TITLE
Feat: 선착순 쿠폰 이벤트를 위한 Coupon 관련 테이블 구조 변경 #33

### DIFF
--- a/src/main/java/piglin/swapswap/domain/coupon/entity/Coupon.java
+++ b/src/main/java/piglin/swapswap/domain/coupon/entity/Coupon.java
@@ -2,6 +2,8 @@ package piglin.swapswap.domain.coupon.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -29,6 +31,7 @@ public class Coupon extends BaseTime {
     private String name;
 
     @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
     private CouponType couponType;
 
     @Column(nullable = false)

--- a/src/main/java/piglin/swapswap/domain/coupon/entity/Coupon.java
+++ b/src/main/java/piglin/swapswap/domain/coupon/entity/Coupon.java
@@ -38,7 +38,7 @@ public class Coupon extends BaseTime {
     private int discountPercentage;
 
     @Column(nullable = false)
-    private LocalDateTime expired_time;
+    private LocalDateTime expiredTime;
 
     @Column(nullable = false)
     private int count;

--- a/src/main/java/piglin/swapswap/domain/membercoupon/entity/MemberCoupon.java
+++ b/src/main/java/piglin/swapswap/domain/membercoupon/entity/MemberCoupon.java
@@ -1,10 +1,12 @@
-package piglin.swapswap.domain.coupon.entity;
+package piglin.swapswap.domain.membercoupon.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -13,13 +15,14 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import piglin.swapswap.domain.common.BaseTime;
 import piglin.swapswap.domain.coupon.constant.CouponType;
+import piglin.swapswap.domain.member.entity.Member;
 
 @Entity
 @Builder
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Coupon extends BaseTime {
+public class MemberCoupon extends BaseTime {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -37,7 +40,8 @@ public class Coupon extends BaseTime {
     @Column(nullable = false)
     private LocalDateTime expired_time;
 
-    @Column(nullable = false)
-    private int count;
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
 
 }

--- a/src/main/java/piglin/swapswap/domain/membercoupon/entity/MemberCoupon.java
+++ b/src/main/java/piglin/swapswap/domain/membercoupon/entity/MemberCoupon.java
@@ -2,6 +2,8 @@ package piglin.swapswap.domain.membercoupon.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -32,6 +34,7 @@ public class MemberCoupon extends BaseTime {
     private String name;
 
     @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
     private CouponType couponType;
 
     @Column(nullable = false)

--- a/src/main/java/piglin/swapswap/domain/membercoupon/entity/MemberCoupon.java
+++ b/src/main/java/piglin/swapswap/domain/membercoupon/entity/MemberCoupon.java
@@ -41,7 +41,7 @@ public class MemberCoupon extends BaseTime {
     private int discountPercentage;
 
     @Column(nullable = false)
-    private LocalDateTime expired_time;
+    private LocalDateTime expiredTime;
 
     @ManyToOne(optional = false)
     @JoinColumn(name = "member_id", nullable = false)


### PR DESCRIPTION
## 📝 개요
- 선착순 쿠폰 이벤트를 위한 Coupon 관련 테이블 구조 변경
<br>

## 👨‍💻 작업 내용
- 기존 하나의 쿠폰 테이블만 가지고 있던 구조에서 아래 그림과 같이 변경
![image](https://github.com/Team-Piglin/swapswap/assets/40788498/fd66c4b5-9f5b-4bbc-b2e7-05ad87e9ac43)
- 선착순 쿠폰 이벤트를 위해 쿠폰의 갯수를 필드로 가진 쿠폰 엔티티와
- 유저가 가지고 있는 쿠폰을 나타낼 수 있는 유저-쿠폰 엔티티로 구조 변경
<br>

## 🙇🏻‍♂️ 리뷰어에게
- 첨부한 ERD와 엔티티 구현이 일치하는지를 중점으로 봐주시면 감사하겠습니다.
<br>
