### PR TITLE
Feat: 쿠폰 생성 기능 추가

### DIFF
--- a/src/main/java/piglin/swapswap/domain/coupon/controller/CouponController.java
+++ b/src/main/java/piglin/swapswap/domain/coupon/controller/CouponController.java
@@ -1,0 +1,53 @@
+package piglin.swapswap.domain.coupon.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+import piglin.swapswap.domain.coupon.constant.CouponType;
+import piglin.swapswap.domain.coupon.dto.request.CouponCreateRequestDto;
+import piglin.swapswap.domain.coupon.service.CouponService;
+
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("/coupons")
+public class CouponController {
+
+    private final CouponService couponService;
+
+    @GetMapping
+    public String createCouponForm(Model model) {
+
+        model.addAttribute("couponCreateRequestDto", new CouponCreateRequestDto(
+                null, null, 0, null, 0));
+        model.addAttribute("couponType", CouponType.values());
+
+        return "coupon/createCouponForm";
+    }
+
+    @PostMapping
+    public String createCoupon(
+            @Valid @ModelAttribute("couponCreateRequestDto") CouponCreateRequestDto couponCreateRequestDto,
+            BindingResult bindingResult, RedirectAttributes redirectAttributes) {
+
+        if (bindingResult.hasErrors()) {
+            return "coupon/createCouponForm";
+        }
+
+        try {
+            Long couponId = couponService.createCoupon(couponCreateRequestDto);
+            redirectAttributes.addAttribute("couponId", couponId);
+        } catch (Exception e) {
+            bindingResult.reject("쿠폰 등록 중 에러가 발생하였습니다.");
+            return "coupon/createCouponForm";
+        }
+
+        return "redirect:/coupon/{couponId}";
+    }
+}

--- a/src/main/java/piglin/swapswap/domain/coupon/dto/request/CouponCreateRequestDto.java
+++ b/src/main/java/piglin/swapswap/domain/coupon/dto/request/CouponCreateRequestDto.java
@@ -1,0 +1,17 @@
+package piglin.swapswap.domain.coupon.dto.request;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import java.time.LocalDateTime;
+import org.hibernate.validator.constraints.Length;
+import org.springframework.format.annotation.DateTimeFormat;
+import piglin.swapswap.domain.coupon.constant.CouponType;
+
+public record CouponCreateRequestDto(@NotBlank @Length(max = 60) String couponName,
+                                     CouponType couponType,
+                                     @Min(1) @Max(100) int discountPercentage,
+                                     @DateTimeFormat LocalDateTime expiredTime,
+                                     @Min(1) int couponCount) {
+
+}

--- a/src/main/java/piglin/swapswap/domain/coupon/dto/request/CouponCreateRequestDto.java
+++ b/src/main/java/piglin/swapswap/domain/coupon/dto/request/CouponCreateRequestDto.java
@@ -5,13 +5,12 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import java.time.LocalDateTime;
 import org.hibernate.validator.constraints.Length;
-import org.springframework.format.annotation.DateTimeFormat;
 import piglin.swapswap.domain.coupon.constant.CouponType;
 
-public record CouponCreateRequestDto(@NotBlank @Length(max = 60) String couponName,
+public record CouponCreateRequestDto(@NotBlank @Length(min = 3, max = 60) String couponName,
                                      CouponType couponType,
                                      @Min(1) @Max(100) int discountPercentage,
-                                     @DateTimeFormat LocalDateTime expiredTime,
+                                     LocalDateTime expiredTime,
                                      @Min(1) int couponCount) {
 
 }

--- a/src/main/java/piglin/swapswap/domain/coupon/mapper/CouponMapper.java
+++ b/src/main/java/piglin/swapswap/domain/coupon/mapper/CouponMapper.java
@@ -1,0 +1,19 @@
+package piglin.swapswap.domain.coupon.mapper;
+
+import piglin.swapswap.domain.coupon.dto.request.CouponCreateRequestDto;
+import piglin.swapswap.domain.coupon.entity.Coupon;
+
+public class CouponMapper {
+
+    public static Coupon createCoupon(CouponCreateRequestDto couponCreateRequestDto) {
+
+        return Coupon.builder()
+                .name(couponCreateRequestDto.couponName())
+                .couponType(couponCreateRequestDto.couponType())
+                .discountPercentage(couponCreateRequestDto.discountPercentage())
+                .expiredTime(couponCreateRequestDto.expiredTime())
+                .count(couponCreateRequestDto.couponCount())
+                .build();
+    }
+
+}

--- a/src/main/java/piglin/swapswap/domain/coupon/repository/CouponRepository.java
+++ b/src/main/java/piglin/swapswap/domain/coupon/repository/CouponRepository.java
@@ -1,0 +1,8 @@
+package piglin.swapswap.domain.coupon.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import piglin.swapswap.domain.coupon.entity.Coupon;
+
+public interface CouponRepository extends JpaRepository<Coupon, Long> {
+
+}

--- a/src/main/java/piglin/swapswap/domain/coupon/service/CouponService.java
+++ b/src/main/java/piglin/swapswap/domain/coupon/service/CouponService.java
@@ -1,0 +1,9 @@
+package piglin.swapswap.domain.coupon.service;
+
+import piglin.swapswap.domain.coupon.dto.request.CouponCreateRequestDto;
+
+public interface CouponService {
+
+    Long createCoupon(CouponCreateRequestDto couponCreateRequestDto);
+
+}

--- a/src/main/java/piglin/swapswap/domain/coupon/service/CouponServiceImplV1.java
+++ b/src/main/java/piglin/swapswap/domain/coupon/service/CouponServiceImplV1.java
@@ -6,6 +6,7 @@ import piglin.swapswap.domain.coupon.dto.request.CouponCreateRequestDto;
 import piglin.swapswap.domain.coupon.entity.Coupon;
 import piglin.swapswap.domain.coupon.mapper.CouponMapper;
 import piglin.swapswap.domain.coupon.repository.CouponRepository;
+import piglin.swapswap.domain.coupon.validator.CouponValidator;
 
 @Service
 @RequiredArgsConstructor
@@ -15,6 +16,8 @@ public class CouponServiceImplV1 implements CouponService {
 
     @Override
     public Long createCoupon(CouponCreateRequestDto couponCreateRequestDto) {
+
+        CouponValidator.validateExpiredTime(couponCreateRequestDto.expiredTime());
 
         // TODO 추후에 어드민 검증해야함.
         Coupon coupon = CouponMapper.createCoupon(couponCreateRequestDto);

--- a/src/main/java/piglin/swapswap/domain/coupon/service/CouponServiceImplV1.java
+++ b/src/main/java/piglin/swapswap/domain/coupon/service/CouponServiceImplV1.java
@@ -1,0 +1,27 @@
+package piglin.swapswap.domain.coupon.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import piglin.swapswap.domain.coupon.dto.request.CouponCreateRequestDto;
+import piglin.swapswap.domain.coupon.entity.Coupon;
+import piglin.swapswap.domain.coupon.mapper.CouponMapper;
+import piglin.swapswap.domain.coupon.repository.CouponRepository;
+
+@Service
+@RequiredArgsConstructor
+public class CouponServiceImplV1 implements CouponService {
+
+    private final CouponRepository couponRepository;
+
+    @Override
+    public Long createCoupon(CouponCreateRequestDto couponCreateRequestDto) {
+
+        // TODO 추후에 어드민 검증해야함.
+        Coupon coupon = CouponMapper.createCoupon(couponCreateRequestDto);
+
+        Coupon savedCoupon = couponRepository.save(coupon);
+
+        return savedCoupon.getId();
+    }
+
+}

--- a/src/main/java/piglin/swapswap/domain/coupon/validator/CouponValidator.java
+++ b/src/main/java/piglin/swapswap/domain/coupon/validator/CouponValidator.java
@@ -1,0 +1,16 @@
+package piglin.swapswap.domain.coupon.validator;
+
+import java.time.LocalDateTime;
+import piglin.swapswap.global.exception.common.ErrorCode;
+import piglin.swapswap.global.exception.coupon.CouponExpiredTimeException;
+
+public class CouponValidator {
+
+    public static void validateExpiredTime(LocalDateTime expiredTime) {
+
+        if (expiredTime.isBefore(LocalDateTime.now())) {
+            throw new CouponExpiredTimeException(ErrorCode.INVALID_EXPIRED_TIME_EXCEPTION);
+        }
+    }
+
+}

--- a/src/main/java/piglin/swapswap/global/exception/common/ErrorCode.java
+++ b/src/main/java/piglin/swapswap/global/exception/common/ErrorCode.java
@@ -34,7 +34,10 @@ public enum ErrorCode {
     NOT_FOUND_COMMENT_EXCEPTION(401, "해당 댓글을 찾을 수 없습니다."),
 
     // 게시글
-    NOT_FOUND_POST_EXCEPTION(401, "게시글을 찾을 수 없습니다.");
+    NOT_FOUND_POST_EXCEPTION(401, "게시글을 찾을 수 없습니다."),
+
+    // 쿠폰
+    INVALID_EXPIRED_TIME_EXCEPTION(401, "만료 시간은 현재 시간보다 이전 시간일 수 없습니다.");
 
     private final int status;
 

--- a/src/main/java/piglin/swapswap/global/exception/coupon/CouponExpiredTimeException.java
+++ b/src/main/java/piglin/swapswap/global/exception/coupon/CouponExpiredTimeException.java
@@ -1,0 +1,11 @@
+package piglin.swapswap.global.exception.coupon;
+
+import piglin.swapswap.global.exception.common.BusinessException;
+import piglin.swapswap.global.exception.common.ErrorCode;
+
+public class CouponExpiredTimeException extends BusinessException {
+
+    public CouponExpiredTimeException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/resources/static/style.css
+++ b/src/main/resources/static/style.css
@@ -10,7 +10,7 @@ body{
 .header {
   background-color: #ffffff;
   border-bottom: 1px #E5E5E5 solid;
-  position: fixed;
+  position: relative;
   width: 100%;
   top: 0;
   z-index: 1000;
@@ -143,4 +143,90 @@ img {
 .text-muted {
   color: #666;
   font-size: 0.8em;
+}
+
+/**
+포스트 Write CSS
+ */
+
+.write-bar-container {
+  color: #333333;
+  width: 100%;
+  height: 400px;
+}
+
+.write-bar {
+  display: flex;
+  align-items: center;
+  border-bottom: 1px solid #E5E5E5;
+  height: 33%;
+}
+
+.write-bar-explain {
+  flex-basis: 30%;
+  font-size: 60px;
+  text-align: center;
+}
+
+.write-bar-title-input {
+  flex-grow: 1;
+  height: 100%;
+  font-size: 80px;
+}
+
+/*.write-content-container {*/
+/*  height: 500px;*/
+/*  background-color: aqua;*/
+/*}*/
+
+.write-content-input {
+  flex-grow: 1;
+  width: 100%;
+  height: 500px;
+}
+
+.write-complete-button {
+  color: #333333;
+  background-color: #ffffff;
+  height: 50px;
+  border-radius: 20px;
+  transition: background-color 0.3s;
+}
+
+.write-complete-button:hover {
+  color: #ffffff;
+  background-color: #00AADC;
+}
+
+.write-bar-image-input {
+  flex-grow: 1;
+  height: 40px; /* Adjust as needed */
+  border-radius: 5px;
+  border: 1px solid #ddd;
+  padding: 5px;
+}
+
+.category-button-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-top: 20px;
+}
+
+.category-button, .couponType-button {
+  padding: 8px 16px;
+  border-radius: 20px;
+  text-decoration: none;
+  color: #333;
+  text-align: center;
+  background-color: #ffffff;
+  border: 1px solid #E5E5E5;
+  margin: 0 10px;
+  transition: background-color 0.3s, color 0.3s;
+  cursor: pointer;
+}
+
+.active, .category-button:hover {
+  background-color: #00AADC;
+  color: #ffffff;
 }

--- a/src/main/resources/templates/coupon/createCouponForm.html
+++ b/src/main/resources/templates/coupon/createCouponForm.html
@@ -1,0 +1,59 @@
+<!DOCTYPE HTML>
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout=http://www.ultraq.net.nz/thymeleaf/layout
+      layout:decorate="~{common/layout/layout}">
+<body>
+<div layout:fragment="content">
+  <script>
+    function selectCouponType(data) {
+      var couponValue = data.getAttribute('value');
+      document.getElementById('couponTypeInput').value = couponValue;
+      console.log(couponValue);
+
+      document.querySelectorAll('.couponType-button').forEach(button => {
+        button.classList.remove('active')
+      });
+
+      event.target.classList.add('active')
+    }
+  </script>
+  <form th:action="@{/coupons}" th:object="${couponCreateRequestDto}" method="post"
+        enctype="application/x-www-form-urlencoded">
+    <div class="write-bar-container">
+      <div class="write-bar">
+        <div class="write-bar-explain">쿠폰 이름</div>
+        <input class="write-bar-title-input" th:field="*{couponName}">
+      </div>
+
+      <div class="write-bar">
+        <div class="write-bar-explain">쿠폰 종류</div>
+        <input type="hidden" th:field="*{couponType}" id="couponTypeInput">
+        <div th:each="type : ${couponType}">
+          <button type="button" th:value="${type}" th:text="${type}" class="couponType-button"
+                  onclick="selectCouponType(this)">
+          </button>
+        </div>
+      </div>
+
+      <div class="write-bar">
+        <div class="write-bar-explain ">쿠폰 할인율</div>
+        <input class="write-bar-title-input" type="number" th:field="*{discountPercentage}"
+               required>
+      </div>
+
+      <div class="write-bar">
+        <div class="write-bar-explain">만료 기한</div>
+        <input class="write-bar-title-input" type="datetime-local" th:field="*{expiredTime}"
+               required>
+      </div>
+
+      <div class="write-bar">
+        <div class="write-bar-explain">쿠폰 갯수</div>
+        <input class="write-bar-title-input" type="number" th:field="*{couponCount}" required>
+      </div>
+      <button type="submit" class="write-complete-button">쿠폰 등록</button>
+    </div>
+  </form>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## 📝 개요
- 쿠폰을 생성하는 기능을 추가하였습니다.
<br>

## 👨‍💻 작업 내용
- #8 해당 이슈를 참고하여 쿠폰 생성 기능을 구현하였습니다.
<br>

## 🙇🏻‍♂️ 리뷰어에게
- 현재 User 파트가 완성되지 않아 관리자 검증은 완료하지 못한 상태입니다.
- 추후에 User 파트가 완성되면 검증 코드 추가와 검증 테스트를 추가할 것 입니다.
- 나중에 쿠폰 사용 시, 만료 기한이 지난 쿠폰 사용 검증을 추가하기 위해 `CouponValidator`를 생성하여 쿠폰에 대한 검증 클래스를 따로 두었습니다.
- 고민 했던 점은 나중에 어드민 검증이 추가되면 `createCoupon() `메서드에서 검증하는 코드만 2줄일텐데 이를 service 클래스에서 따로 validate 메서드를 생성해서 묶어서 처리할지 아니면 두 줄의 코드를 그대로 둘지 고민입니다.
<br>
