### PR TITLE
refactor: createPost 매개변수 MemberId -> Member 변경

### DIFF
--- a/src/main/java/piglin/swapswap/domain/post/controller/PostController.java
+++ b/src/main/java/piglin/swapswap/domain/post/controller/PostController.java
@@ -21,7 +21,7 @@ public class PostController {
 
     @PostMapping("/write")
     public String createPost(@Valid @ModelAttribute PostCreateRequestDto requestDto
-            , @AuthUser Member member) {
+            , @AuthMember Member member) {
 
         return "redirect:/posts/" + postService.createPost(member, requestDto)
                 .toString();

--- a/src/main/java/piglin/swapswap/domain/post/controller/PostController.java
+++ b/src/main/java/piglin/swapswap/domain/post/controller/PostController.java
@@ -8,9 +8,9 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import piglin.swapswap.domain.member.entity.Member;
 import piglin.swapswap.domain.post.dto.request.PostCreateRequestDto;
 import piglin.swapswap.domain.post.service.PostService;
-import piglin.swapswap.global.security.UserDetailsImpl;
 
 @Controller
 @RequestMapping("/posts")
@@ -21,16 +21,18 @@ public class PostController {
 
     @PostMapping("/write")
     public String createPost(@Valid @ModelAttribute PostCreateRequestDto requestDto
-            , @AuthenticationPrincipal UserDetailsImpl userDetails) {
+            , @AuthUser Member member) {
 
-        return "redirect:/posts/" + postService.createPost(userDetails.getUserId(), requestDto)
+        return "redirect:/posts/" + postService.createPost(member, requestDto)
                 .toString();
     }
 
     @GetMapping("/write")
     public String getPostWriteForm(Model model) {
+
         model.addAttribute("PostCreateRequestDto",
                 new PostCreateRequestDto(null, null, null, null));
+
         return "post/postWrite";
     }
 }

--- a/src/main/java/piglin/swapswap/domain/post/service/PostService.java
+++ b/src/main/java/piglin/swapswap/domain/post/service/PostService.java
@@ -1,5 +1,6 @@
 package piglin.swapswap.domain.post.service;
 
+import piglin.swapswap.domain.member.entity.Member;
 import piglin.swapswap.domain.post.dto.request.PostCreateRequestDto;
 
 public interface PostService {
@@ -7,9 +8,9 @@ public interface PostService {
     /**
      * 게시글을 생성하는 메소드입니다.
      *
-     * @param memberId   Post 내에 들어갈 memberId 입니다. 이 memberId를 사용하여 예외 처리를 합니다.
+     * @param member   Post 생성 시 연관 관계에 들어갈 member 입니다.
      * @param requestDto Post 를 생성하기 위해서 받는 Request Dto 입니다. Category, Title, Content, ImageUrlList
      *                   로 이루어져 있으며, ImageUrlList는 다중 업로드가 가능합니다.
      */
-    Long createPost(Long memberId, PostCreateRequestDto requestDto);
+    Long createPost(Member member, PostCreateRequestDto requestDto);
 }

--- a/src/main/java/piglin/swapswap/domain/post/service/PostServiceImplV1.java
+++ b/src/main/java/piglin/swapswap/domain/post/service/PostServiceImplV1.java
@@ -25,9 +25,7 @@ public class PostServiceImplV1 implements PostService {
     private final S3ImageServiceImplV1 s3ImageServiceImplV1;
 
     @Override
-    public Long createPost(Long memberId, PostCreateRequestDto requestDto) {
-
-        Member member = getMember(memberId);
+    public Long createPost(Member member, PostCreateRequestDto requestDto) {
 
         imageUrlListSizeCheck(requestDto);
 
@@ -46,6 +44,7 @@ public class PostServiceImplV1 implements PostService {
     }
 
     private void imageUrlListSizeCheck(PostCreateRequestDto requestDto) {
+
         if (requestDto.imageUrlList().size() < PostConstant.IMAGE_MIN_SIZE) {
             throw new BusinessException(ErrorCode.POST_IMAGE_MIN_SIZE);
         }
@@ -55,11 +54,5 @@ public class PostServiceImplV1 implements PostService {
         if (requestDto.imageUrlList().size() > PostConstant.IMAGE_MAX_SIZE) {
             throw new BusinessException(ErrorCode.POST_IMAGE_MAX_SIZE);
         }
-    }
-
-    private Member getMember(Long memberId) {
-        return memberRepository.findById(memberId).orElseThrow(
-                () -> new BusinessException(ErrorCode.NOT_FOUND_USER_EXCEPTION)
-        );
     }
 }

--- a/src/test/java/piglin/swapswap/domain/post/service/PostServiceImplV1UnitTest.java
+++ b/src/test/java/piglin/swapswap/domain/post/service/PostServiceImplV1UnitTest.java
@@ -49,7 +49,7 @@ class PostServiceImplV1UnitTest {
 
     @BeforeEach
     void setUp() {
-        member = Member.builder().id(1L).build();
+        member = Member.builder().id(memberId).build();
     }
 
     @Nested
@@ -66,10 +66,9 @@ class PostServiceImplV1UnitTest {
                     "내용",
                     imageUrlList);
 
-            when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
             when(s3ImageServiceImplV1.saveImageUrlList(any())).thenReturn(new ArrayList<>());
             // When
-            postService.createPost(memberId, requestDto);
+            postService.createPost(member, requestDto);
             // Then
             verify(postRepository).save(any(Post.class));
         }
@@ -83,9 +82,8 @@ class PostServiceImplV1UnitTest {
                     "내용",
                     imageUrlList);
 
-            when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
             // When - Then
-            assertThatThrownBy(() -> postService.createPost(memberId, requestDto))
+            assertThatThrownBy(() -> postService.createPost(member, requestDto))
                     .isInstanceOf(RuntimeException.class)
                     .hasMessageContaining(ErrorCode.POST_IMAGE_MIN_SIZE.getMessage());
         }
@@ -104,30 +102,10 @@ class PostServiceImplV1UnitTest {
                     "내용",
                     imageUrlList);
 
-            when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
             // When - Then
-            assertThatThrownBy(() -> postService.createPost(memberId, requestDto))
+            assertThatThrownBy(() -> postService.createPost(member, requestDto))
                     .isInstanceOf(RuntimeException.class)
                     .hasMessageContaining(ErrorCode.POST_IMAGE_MAX_SIZE.getMessage());
-        }
-
-        @Test
-        @DisplayName("게시글 저장 - 실패 / 유저를 찾을 수 없습니다.")
-        void createPost_Fail_User_Not_Found() {
-            // Given
-            Long invalidMemberId = 999L;
-            List<MultipartFile> imageUrlList = new ArrayList<>();
-            imageUrlList.add(Mockito.mock(MultipartFile.class));
-
-            PostCreateRequestDto requestDto = new PostCreateRequestDto(Category.ELECTRONICS, "제목",
-                    "내용",
-                    imageUrlList);
-
-            when(memberRepository.findById(invalidMemberId)).thenReturn(Optional.empty());
-            // When - Then
-            assertThatThrownBy(() -> postService.createPost(invalidMemberId, requestDto))
-                    .isInstanceOf(RuntimeException.class)
-                    .hasMessageContaining(ErrorCode.NOT_FOUND_USER_EXCEPTION.getMessage());
         }
     }
 


### PR DESCRIPTION
## 📝 개요
- [#40 ] 이슈에 관한 내용입니다.
- 간략하게 요약하면, DB 조회 한번만 해도 되는 걸 두번해야 되는 일이 생겼습니다.
<br>

## 👨‍💻 작업 내용
- MemberId를 받는 부분을 Member로 받게 끔 진행했습니다.
- 이에 따른 테스트 코드 로직을 수정했습니다.
- 사용하지 않는 메소드는 제거했습니다.
<br>

## 🙇🏻‍♂️ 리뷰어에게
- 아직 유저 인증 인가가 구현되지 않아, 구현 후 @AuthUser 어노테이션을 쓴다는 가정하에 코드를 적었습니다.
- 테스트 코드 통과 및 직접 테스트 했을 때도 문제 없었습니다.
<br>
