### PR TITLE
bugfix: 로그인 안 한 사용자가 게시글을 작성할 수 있는 오류 수정

### DIFF
--- a/src/main/java/piglin/swapswap/domain/post/controller/PostController.java
+++ b/src/main/java/piglin/swapswap/domain/post/controller/PostController.java
@@ -7,20 +7,18 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
 import piglin.swapswap.domain.member.entity.Member;
 import piglin.swapswap.domain.post.dto.request.PostCreateRequestDto;
 import piglin.swapswap.domain.post.service.PostService;
 import piglin.swapswap.global.annotation.AuthMember;
 
 @Controller
-@RequestMapping("/posts")
 @RequiredArgsConstructor
 public class PostController {
 
     private final PostService postService;
 
-    @PostMapping("/write")
+    @PostMapping("/posts/write")
     public String createPost(@Valid @ModelAttribute PostCreateRequestDto requestDto
             , @AuthMember Member member) {
 
@@ -28,8 +26,12 @@ public class PostController {
                 .toString();
     }
 
-    @GetMapping("/write")
-    public String getPostWriteForm(Model model) {
+    @GetMapping("/posts/write")
+    public String getPostWriteForm(Model model, @AuthMember Member member) {
+
+        if (member == null) {
+            return "redirect:/";
+        }
 
         model.addAttribute("PostCreateRequestDto",
                 new PostCreateRequestDto(null, null, null, null));

--- a/src/main/java/piglin/swapswap/domain/post/service/PostServiceImplV1.java
+++ b/src/main/java/piglin/swapswap/domain/post/service/PostServiceImplV1.java
@@ -29,6 +29,10 @@ public class PostServiceImplV1 implements PostService {
 
         imageUrlListSizeCheck(requestDto);
 
+        if (member == null) {
+           throw new BusinessException(ErrorCode.WRITE_ONLY_USER);
+        }
+
         List<String> imageUrlList = s3ImageServiceImplV1.saveImageUrlList(
                 requestDto.imageUrlList());
         Map<Integer, Object> imageUrlMap = new HashMap<>();

--- a/src/main/java/piglin/swapswap/global/config/WebSecurityConfig.java
+++ b/src/main/java/piglin/swapswap/global/config/WebSecurityConfig.java
@@ -54,6 +54,7 @@ public class WebSecurityConfig {
                 authorizeHttpRequests
                         .requestMatchers("/login", "/api/login/**").permitAll()
                         .requestMatchers("/", "/posts/{postId}").permitAll()
+                        .requestMatchers("/posts/write}").authenticated()
                         .anyRequest().authenticated()
         );
 

--- a/src/main/java/piglin/swapswap/global/config/WebSecurityConfig.java
+++ b/src/main/java/piglin/swapswap/global/config/WebSecurityConfig.java
@@ -54,7 +54,7 @@ public class WebSecurityConfig {
                 authorizeHttpRequests
                         .requestMatchers("/login", "/api/login/**").permitAll()
                         .requestMatchers("/", "/posts/{postId}").permitAll()
-                        .requestMatchers("/posts/write}").authenticated()
+                        .requestMatchers("/posts/write").authenticated()
                         .anyRequest().authenticated()
         );
 

--- a/src/main/java/piglin/swapswap/global/exception/common/ErrorCode.java
+++ b/src/main/java/piglin/swapswap/global/exception/common/ErrorCode.java
@@ -35,6 +35,7 @@ public enum ErrorCode {
 
     // 게시글
     NOT_FOUND_POST_EXCEPTION(401, "게시글을 찾을 수 없습니다."),
+    WRITE_ONLY_USER(401, "로그인 한 유저만 게시글을 작성할 수 있습니다"),
   
     // 쿠폰
     INVALID_EXPIRED_TIME_EXCEPTION(401, "만료 시간은 현재 시간보다 이전 시간일 수 없습니다."),


### PR DESCRIPTION
## 📝 개요
- [#49 ] 에 관한 내용입니다.
- 로그인 안 한 사용자가 게시글을 작성할 수 있던 오류가 있었습니다.
<br>

## 👨‍💻 작업 내용
- 시큐리티에 posts/write 추가했습니다
- 더블 체킹 할 수 있도로 서비스, 컨트롤러 단에서도 예외를 발생하게 작성했습니다.
<br>

## 🙇🏻‍♂️ 리뷰어에게
- 우선 get은 리다이렉트, post는 커스텀 예외를 발생하게 했는데, 이게 맞을지 모르겠습니다.. 시큐리티가 정상 작동해서 애초부터 막을 수 있게하면 막을 수 있는데, 혹시 몰라서 더블 체킹으로 해놨습니다.
<br>
