### PR TITLE
feat: getPostList 반환 Page로 반환 하게 수정

### DIFF
--- a/src/main/java/piglin/swapswap/domain/post/controller/PostController.java
+++ b/src/main/java/piglin/swapswap/domain/post/controller/PostController.java
@@ -69,7 +69,7 @@ public class PostController {
 
         Pageable pageable = PageRequest.of(page, size, Sort.by(Direction.DESC, sort));
 
-        model.addAttribute("PostGetListResponseDtoMap", postService.getPostList(member, pageable));
+        model.addAttribute("PostGetListResponseDtoPage", postService.getPostList(member, pageable));
 
         return "post/postList";
     }

--- a/src/main/java/piglin/swapswap/domain/post/dto/response/PostGetListResponseDto.java
+++ b/src/main/java/piglin/swapswap/domain/post/dto/response/PostGetListResponseDto.java
@@ -4,6 +4,8 @@ import lombok.Builder;
 
 @Builder
 public record PostGetListResponseDto(
+        Long postId,
+        Long memberId,
         String title,
         String thumbnailUrl,
         String modifiedUpTime,

--- a/src/main/java/piglin/swapswap/domain/post/mapper/PostMapper.java
+++ b/src/main/java/piglin/swapswap/domain/post/mapper/PostMapper.java
@@ -2,7 +2,11 @@ package piglin.swapswap.domain.post.mapper;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.List;
 import java.util.Map;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import piglin.swapswap.domain.member.entity.Member;
 import piglin.swapswap.domain.post.dto.request.PostCreateRequestDto;
 import piglin.swapswap.domain.post.dto.request.PostUpdateRequestDto;
@@ -49,6 +53,8 @@ public class PostMapper {
             boolean favoriteStatus) {
 
         return PostGetListResponseDto.builder()
+                                     .postId(post.getId())
+                                     .memberId(post.getMember().getId())
                                      .title(post.getTitle())
                                      .thumbnailUrl(post.getImageUrl().get(0).toString())
                                      .modifiedUpTime(post.getModifiedUpTime().format(DateTimeFormatter.ISO_DATE_TIME))
@@ -62,5 +68,10 @@ public class PostMapper {
             Map<Integer, Object> imageUrlMap) {
 
         post.updatePost(requestDto.title(), requestDto.content(), imageUrlMap, requestDto.category());
+    }
+
+    public static Page<PostGetListResponseDto> toDtoList(List<PostGetListResponseDto> responseDtoList, Pageable pageable, Long totalElements) {
+
+        return new PageImpl<>(responseDtoList, pageable, totalElements);
     }
 }

--- a/src/main/java/piglin/swapswap/domain/post/mapper/PostMapper.java
+++ b/src/main/java/piglin/swapswap/domain/post/mapper/PostMapper.java
@@ -70,7 +70,7 @@ public class PostMapper {
         post.updatePost(requestDto.title(), requestDto.content(), imageUrlMap, requestDto.category());
     }
 
-    public static Page<PostGetListResponseDto> toDtoList(List<PostGetListResponseDto> responseDtoList, Pageable pageable, Long totalElements) {
+    public static Page<PostGetListResponseDto> toPageDtoList(List<PostGetListResponseDto> responseDtoList, Pageable pageable, Long totalElements) {
 
         return new PageImpl<>(responseDtoList, pageable, totalElements);
     }

--- a/src/main/java/piglin/swapswap/domain/post/service/PostService.java
+++ b/src/main/java/piglin/swapswap/domain/post/service/PostService.java
@@ -1,6 +1,6 @@
 package piglin.swapswap.domain.post.service;
 
-import java.util.Map;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import piglin.swapswap.domain.member.entity.Member;
 import piglin.swapswap.domain.post.dto.request.PostCreateRequestDto;
@@ -29,10 +29,11 @@ public interface PostService {
 
     /**
      * 게시글 목록 조회 메소드입니다.
+     *
      * @param member favorite 상태를 나타내기 위한 member 매개변수 입니다.
-     * @return Map 형식으로 이루어져 있으며 Key 에는 Post Id가, Value 에는 PostGetListResponseDto 가 들어갑니다.
+     * @return Paging 처리가 된 PostGetListResponseDto 가 들어갑니다.
      */
-    Map<Long, PostGetListResponseDto> getPostList(Member member, Pageable pageable);
+    Page<PostGetListResponseDto> getPostList(Member member, Pageable pageable);
 
     /**
      * 게시글 찜 기능입니다.

--- a/src/main/java/piglin/swapswap/domain/post/service/PostServiceImplV1.java
+++ b/src/main/java/piglin/swapswap/domain/post/service/PostServiceImplV1.java
@@ -98,7 +98,7 @@ public class PostServiceImplV1 implements PostService {
             responseDtoList.add(PostMapper.postToGetListResponseDto(post, favoriteCnt, favoriteStatus));
         }
 
-        return PostMapper.toDtoList(responseDtoList, pageable, postPage.getTotalElements());
+        return PostMapper.toPageDtoList(responseDtoList, pageable, postPage.getTotalElements());
     }
 
     @Override

--- a/src/main/java/piglin/swapswap/domain/post/service/PostServiceImplV1.java
+++ b/src/main/java/piglin/swapswap/domain/post/service/PostServiceImplV1.java
@@ -1,8 +1,8 @@
 package piglin.swapswap.domain.post.service;
 
 import jakarta.transaction.Transactional;
+import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
@@ -81,13 +81,13 @@ public class PostServiceImplV1 implements PostService {
     }
 
     @Override
-    public Map<Long, PostGetListResponseDto> getPostList(Member member, Pageable pageable) {
+    public Page<PostGetListResponseDto> getPostList(Member member, Pageable pageable) {
 
-        Page<Post> postList = postRepository.findAllByIsDeletedIsFalse(pageable);
+        Page<Post> postPage = postRepository.findAllByIsDeletedIsFalse(pageable);
 
-        Map<Long, PostGetListResponseDto> responseDtoMap = new LinkedHashMap<>();
+        List<PostGetListResponseDto> responseDtoList = new ArrayList<>();
 
-        for (Post post : postList) {
+        for (Post post : postPage) {
             Long favoriteCnt = favoriteService.getPostFavoriteCnt(post);
             boolean favoriteStatus = false;
 
@@ -95,13 +95,10 @@ public class PostServiceImplV1 implements PostService {
                 favoriteStatus = favoriteService.isFavorite(post, member);
             }
 
-            PostGetListResponseDto dto = PostMapper.postToGetListResponseDto(post, favoriteCnt,
-                    favoriteStatus);
-
-            responseDtoMap.put(post.getId(), dto);
+            responseDtoList.add(PostMapper.postToGetListResponseDto(post, favoriteCnt, favoriteStatus));
         }
 
-        return responseDtoMap;
+        return PostMapper.toDtoList(responseDtoList, pageable, postPage.getTotalElements());
     }
 
     @Override

--- a/src/main/resources/templates/post/postList.html
+++ b/src/main/resources/templates/post/postList.html
@@ -17,23 +17,23 @@
   </div>
 
   <div class="post-container">
-    <div th:each="entry:${PostGetListResponseDtoMap.entrySet}" class="post-card">
-      <a th:href="@{/posts/{postId}(postId=${entry.key})}">
+    <div th:each="postDto : ${PostGetListResponseDtoPage.content}" class="post-card">
+      <a th:href="@{/posts/{postId}(postId=${postDto.postId})}">
         <div class="post-image-container">
-          <img th:src="${entry.value.thumbnailUrl}" alt="Post Image" class="post-image">
+          <img th:src="${postDto.thumbnailUrl}" alt="Post Image" class="post-image">
         </div>
-        <h2 th:text="${entry.value.title}" class="post-title"></h2>
+        <h2 th:text="${postDto.title}" class="post-title"></h2>
         <div class="post-stats">
-          <span class="view-count">조회수 <span th:text="${entry.value.viewCnt}"></span></span>
-          <span class="favorite-count">찜 <span th:text="${entry.value.favoriteCnt}"></span></span>
+          <span class="view-count">조회수 <span th:text="${postDto.viewCnt}"></span></span>
+          <span class="favorite-count">찜 <span th:text="${postDto.favoriteCnt}"></span></span>
           <span class="modified-date">올린 날짜 <span
-              th:text="${entry.value.modifiedUpTime}"></span></span>
+              th:text="${postDto.modifiedUpTime}"></span></span>
         </div>
       </a>
       <button
-          th:data-post-id="${entry.key}"
+          th:data-post-id="${postDto.postId}"
           onclick="toggleFavorite(this.getAttribute('data-post-id'))"
-          th:text="${entry.value.favoriteStatus()} == true ? '💙' : '🤍'"
+          th:text="${postDto.favoriteStatus} == true ? '💙' : '🤍'"
           type="button"
       ></button>
     </div>


### PR DESCRIPTION
## 📝 개요
- 기존 로직은 Map<Long, ResponseDto> 로 Key에는 postId 가 들어가게 했습니다.
- 하지만 곰곰히 생각해보니 맵 형식으로 굳이 반환하지 말고 Page로 반환하는 거랑 별반 차이를 못느꼈습니다.
- 추후 개발 될 거래 기능에서도 MemberId와 PostId가 필요하여 Map -> Page 로 바꾸었습니다.
<br>

## 👨‍💻 작업 내용
- Map -> Page 반환 타입 수정
- PostId 및 MemberId 추가 반환
- html 타임리프 수정
<br>

## 🙇🏻‍♂️ 리뷰어에게
- 작명을 좀 이쁘게 못 한 거 같습니다. 이름 추천해주세요
- 기존 html에서 로직적으로는 많이 바뀌지는 않았지만, postList에 관해 작성하시던 코드가 있으시면 제 코드 보시고 바꾸셔야 합니다.
<br>
