### PR TITLE
refactor: 커서 기반 페이지네이션을 위한 N+1 방지 두방 쿼리 리팩토링

### DIFF
--- a/src/main/java/piglin/swapswap/domain/post/controller/PostController.java
+++ b/src/main/java/piglin/swapswap/domain/post/controller/PostController.java
@@ -64,10 +64,9 @@ public class PostController {
     public String getPostList(
             @RequestParam(value = "page", defaultValue = "0") int page,
             @RequestParam(value = "size", defaultValue = "10") int size,
-            @RequestParam(value = "sort", defaultValue = "modifiedUpTime") String sort,
             Model model, @AuthMember Member member) {
 
-        Pageable pageable = PageRequest.of(page, size, Sort.by(Direction.DESC, sort));
+        Pageable pageable = PageRequest.of(page, size);
 
         model.addAttribute("PostGetListResponseDtoPage", postService.getPostList(member, pageable));
 
@@ -128,11 +127,10 @@ public class PostController {
             @AuthMember Member member,
             @RequestParam(value = "page", defaultValue = "0") int page,
             @RequestParam(value = "size", defaultValue = "10") int size,
-            @RequestParam(value = "sort", defaultValue = "modifiedUpTime") String sort,
             Model model
     ) {
 
-        Pageable pageable = PageRequest.of(page, size, Sort.by(Direction.DESC, sort));
+        Pageable pageable = PageRequest.of(page, size);
 
         model.addAttribute("PostGetListResponseDtoPage", postService.searchPost(title, category, member, pageable));
 

--- a/src/main/java/piglin/swapswap/domain/post/controller/PostController.java
+++ b/src/main/java/piglin/swapswap/domain/post/controller/PostController.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
 import piglin.swapswap.domain.member.entity.Member;
 import piglin.swapswap.domain.post.dto.request.PostCreateRequestDto;
 import piglin.swapswap.domain.post.dto.request.PostUpdateRequestDto;
@@ -73,6 +74,7 @@ public class PostController {
         return "post/postList";
     }
 
+    @ResponseBody
     @PatchMapping("/posts/{postId}/favorite")
     public ResponseEntity<?> updatePostFavorite(@AuthMember Member member,
             @PathVariable Long postId) {
@@ -113,6 +115,7 @@ public class PostController {
         return "post/postUpdateWrite";
     }
 
+    @ResponseBody
     @DeleteMapping("/posts/{postId}")
     public ResponseEntity<?> deletePost(@AuthMember Member member, @PathVariable Long postId) {
 
@@ -137,6 +140,7 @@ public class PostController {
         return "post/postList";
     }
 
+    @ResponseBody
     @PatchMapping("/posts/{postId}/up")
     public ResponseEntity<?> upPost(@PathVariable Long postId, @AuthMember Member member) {
 

--- a/src/main/java/piglin/swapswap/domain/post/dto/response/PostGetListResponseDto.java
+++ b/src/main/java/piglin/swapswap/domain/post/dto/response/PostGetListResponseDto.java
@@ -1,17 +1,24 @@
 package piglin.swapswap.domain.post.dto.response;
 
+import java.time.LocalDateTime;
+import java.util.Map;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
-@Builder
-public record PostGetListResponseDto(
-        Long postId,
-        Long memberId,
-        String title,
-        String thumbnailUrl,
-        String modifiedUpTime,
-        Long viewCnt,
-        Long favoriteCnt,
-        boolean favoriteStatus
-) {
-
+@NoArgsConstructor
+@Setter
+@Getter
+@AllArgsConstructor
+public class PostGetListResponseDto {
+    Long postId;
+    Long memberId;
+    String title;
+    Map<Integer, Object> imageUrl;
+    LocalDateTime modifiedUpTime;
+    Long viewCnt;
+    Long favoriteCnt;
+    boolean favoriteStatus;
 }

--- a/src/main/java/piglin/swapswap/domain/post/dto/response/PostGetListResponseDto.java
+++ b/src/main/java/piglin/swapswap/domain/post/dto/response/PostGetListResponseDto.java
@@ -7,10 +7,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-@NoArgsConstructor
-@Setter
 @Getter
-@AllArgsConstructor
+@NoArgsConstructor
 public class PostGetListResponseDto {
 
     Long postId;

--- a/src/main/java/piglin/swapswap/domain/post/dto/response/PostGetListResponseDto.java
+++ b/src/main/java/piglin/swapswap/domain/post/dto/response/PostGetListResponseDto.java
@@ -3,7 +3,6 @@ package piglin.swapswap.domain.post.dto.response;
 import java.time.LocalDateTime;
 import java.util.Map;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -13,12 +12,20 @@ import lombok.Setter;
 @Getter
 @AllArgsConstructor
 public class PostGetListResponseDto {
+
     Long postId;
+
     Long memberId;
+
     String title;
+
     Map<Integer, Object> imageUrl;
+
     LocalDateTime modifiedUpTime;
+
     Long viewCnt;
+
     Long favoriteCnt;
+
     boolean favoriteStatus;
 }

--- a/src/main/java/piglin/swapswap/domain/post/mapper/PostMapper.java
+++ b/src/main/java/piglin/swapswap/domain/post/mapper/PostMapper.java
@@ -49,29 +49,10 @@ public class PostMapper {
                                  .build();
     }
 
-//    public static PostGetListResponseDto postToGetListResponseDto(Post post, Long favoriteCnt,
-//            boolean favoriteStatus) {
-//
-//        return PostGetListResponseDto.builder()
-//                                     .postId(post.getId())
-//                                     .memberId(post.getMember().getId())
-//                                     .title(post.getTitle())
-//                                     .imageUrl(post.getImageUrl())
-//                                     .modifiedUpTime(post.getModifiedUpTime())
-//                                     .viewCnt(post.getViewCnt())
-//                                     .favoriteCnt(favoriteCnt)
-//                                     .favoriteStatus(favoriteStatus)
-//                                     .build();
-//    }
 
     public static void updatePost(Post post, PostUpdateRequestDto requestDto,
             Map<Integer, Object> imageUrlMap) {
 
         post.updatePost(requestDto.title(), requestDto.content(), imageUrlMap, requestDto.category());
-    }
-
-    public static Page<PostGetListResponseDto> toPageDtoList(List<PostGetListResponseDto> responseDtoList, Pageable pageable, Long totalElements) {
-
-        return new PageImpl<>(responseDtoList, pageable, totalElements);
     }
 }

--- a/src/main/java/piglin/swapswap/domain/post/mapper/PostMapper.java
+++ b/src/main/java/piglin/swapswap/domain/post/mapper/PostMapper.java
@@ -49,20 +49,20 @@ public class PostMapper {
                                  .build();
     }
 
-    public static PostGetListResponseDto postToGetListResponseDto(Post post, Long favoriteCnt,
-            boolean favoriteStatus) {
-
-        return PostGetListResponseDto.builder()
-                                     .postId(post.getId())
-                                     .memberId(post.getMember().getId())
-                                     .title(post.getTitle())
-                                     .thumbnailUrl(post.getImageUrl().get(0).toString())
-                                     .modifiedUpTime(post.getModifiedUpTime().format(DateTimeFormatter.ISO_DATE_TIME))
-                                     .viewCnt(post.getViewCnt())
-                                     .favoriteCnt(favoriteCnt)
-                                     .favoriteStatus(favoriteStatus)
-                                     .build();
-    }
+//    public static PostGetListResponseDto postToGetListResponseDto(Post post, Long favoriteCnt,
+//            boolean favoriteStatus) {
+//
+//        return PostGetListResponseDto.builder()
+//                                     .postId(post.getId())
+//                                     .memberId(post.getMember().getId())
+//                                     .title(post.getTitle())
+//                                     .imageUrl(post.getImageUrl())
+//                                     .modifiedUpTime(post.getModifiedUpTime())
+//                                     .viewCnt(post.getViewCnt())
+//                                     .favoriteCnt(favoriteCnt)
+//                                     .favoriteStatus(favoriteStatus)
+//                                     .build();
+//    }
 
     public static void updatePost(Post post, PostUpdateRequestDto requestDto,
             Map<Integer, Object> imageUrlMap) {

--- a/src/main/java/piglin/swapswap/domain/post/repository/PostQueryRepository.java
+++ b/src/main/java/piglin/swapswap/domain/post/repository/PostQueryRepository.java
@@ -2,6 +2,7 @@ package piglin.swapswap.domain.post.repository;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import piglin.swapswap.domain.member.entity.Member;
 import piglin.swapswap.domain.post.constant.Category;
 import piglin.swapswap.domain.post.dto.response.PostGetListResponseDto;
 import piglin.swapswap.domain.post.entity.Post;
@@ -9,4 +10,6 @@ import piglin.swapswap.domain.post.entity.Post;
 public interface PostQueryRepository {
 
     Page<Post> searchPost(String title, Category categoryCond, Pageable pageable);
+
+    Page<PostGetListResponseDto> findAllPostListWithFavoriteAndPaging(Pageable pageable, Member member);
 }

--- a/src/main/java/piglin/swapswap/domain/post/repository/PostQueryRepository.java
+++ b/src/main/java/piglin/swapswap/domain/post/repository/PostQueryRepository.java
@@ -9,7 +9,7 @@ import piglin.swapswap.domain.post.entity.Post;
 
 public interface PostQueryRepository {
 
-    Page<Post> searchPost(String title, Category categoryCond, Pageable pageable);
+    Page<PostGetListResponseDto> searchPost(String title, Category categoryCond, Member member, Pageable pageable);
 
     Page<PostGetListResponseDto> findAllPostListWithFavoriteAndPaging(Pageable pageable, Member member);
 }

--- a/src/main/java/piglin/swapswap/domain/post/repository/PostQueryRepositoryImpl.java
+++ b/src/main/java/piglin/swapswap/domain/post/repository/PostQueryRepositoryImpl.java
@@ -1,15 +1,26 @@
 package piglin.swapswap.domain.post.repository;
 
+import static piglin.swapswap.domain.favorite.entity.QFavorite.*;
 import static piglin.swapswap.domain.post.entity.QPost.*;
 
+import com.querydsl.core.QueryResults;
+import com.querydsl.core.types.Expression;
+import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.CaseBuilder;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.Map;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
+import piglin.swapswap.domain.favorite.entity.QFavorite;
+import piglin.swapswap.domain.member.entity.Member;
 import piglin.swapswap.domain.post.constant.Category;
 import piglin.swapswap.domain.post.dto.response.PostGetListResponseDto;
 import piglin.swapswap.domain.post.entity.Post;
@@ -28,23 +39,52 @@ public class PostQueryRepositoryImpl implements PostQueryRepository {
     }
 
     @Override
+    public Page<PostGetListResponseDto> findAllPostListWithFavoriteAndPaging(Pageable pageable,
+            Member member) {
+        List<PostGetListResponseDto> content = queryFactory
+                .select(Projections.fields(PostGetListResponseDto.class,
+                        post.id.as("postId"),
+                        post.member.id.as("memberId"),
+                        post.title,
+                        post.imageUrl,
+                        post.modifiedUpTime,
+                        post.viewCnt,
+                        favorite.post.count().as("favoriteCnt"),
+                        memberEq(member).as("favoriteStatus")))
+                .from(post)
+                .leftJoin(favorite)
+                .on(favorite.post.eq(post))
+                .groupBy(post.id, favorite.member.id)
+                .limit(pageable.getPageSize())
+                .offset(pageable.getOffset())
+                .fetch();
+
+        Long count = queryFactory.select(post.count())
+                                 .from(post)
+                                 .limit(pageable.getPageSize())
+                                 .offset(pageable.getOffset())
+                                 .fetchOne();
+
+        return new PageImpl<>(content, pageable, count);
+    }
+
+    @Override
     public Page<Post> searchPost(String title, Category categoryCond,
             Pageable pageable) {
 
         List<Post> content = queryFactory.select(post)
-                                         .from(post)
-                                         .where(titleContains(title), categoryEq(categoryCond), post.isDeleted.eq(false))
-                                         .offset(pageable.getOffset())
-                                         .limit(pageable.getPageSize())
-                                         .fetch();
-
+                .from(post)
+                .where(titleContains(title), categoryEq(categoryCond), post.isDeleted.eq(false))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
 
         Long count = queryFactory.select(post.count())
-                                 .from(post)
-                                 .where(titleContains(title), categoryEq(categoryCond), post.isDeleted.eq(false))
-                                 .offset(pageable.getOffset())
-                                 .limit(pageable.getPageSize())
-                                 .fetchOne();
+                .from(post)
+                .where(titleContains(title), categoryEq(categoryCond), post.isDeleted.eq(false))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetchOne();
 
         return new PageImpl<>(content, pageable, count);
     }
@@ -55,5 +95,20 @@ public class PostQueryRepositoryImpl implements PostQueryRepository {
 
     private BooleanExpression categoryEq(Category category) {
         return category != null ? post.category.eq(category) : null;
+    }
+
+    private BooleanExpression memberEq(Member member) {
+
+        Long memberId = null;
+
+        if(member == null) {
+            memberId = 0L;
+        } else {
+            memberId = member.getId();
+        }
+
+        return new CaseBuilder().when(favorite.member.id.eq(memberId))
+                                .then(true)
+                                .otherwise(false);
     }
 }

--- a/src/main/java/piglin/swapswap/domain/post/repository/PostQueryRepositoryImpl.java
+++ b/src/main/java/piglin/swapswap/domain/post/repository/PostQueryRepositoryImpl.java
@@ -32,6 +32,7 @@ public class PostQueryRepositoryImpl implements PostQueryRepository {
     @Override
     public Page<PostGetListResponseDto> findAllPostListWithFavoriteAndPaging(Pageable pageable,
             Member member) {
+
         List<PostGetListResponseDto> content = queryFactory
                 .select(Projections.fields(PostGetListResponseDto.class,
                         post.id.as("postId"),
@@ -52,10 +53,10 @@ public class PostQueryRepositoryImpl implements PostQueryRepository {
                 .fetch();
 
         Long count = queryFactory.select(post.count())
-                .from(post)
-                .limit(pageable.getPageSize())
-                .offset(pageable.getOffset())
-                .fetchOne();
+                                 .from(post)
+                                 .limit(pageable.getPageSize())
+                                 .offset(pageable.getOffset())
+                                 .fetchOne();
 
         return new PageImpl<>(content, pageable, count);
     }
@@ -64,7 +65,7 @@ public class PostQueryRepositoryImpl implements PostQueryRepository {
     public Page<PostGetListResponseDto> searchPost(String title, Category categoryCond,
             Member member,
             Pageable pageable) {
-//        NumberTemplate.ONE.when(favorite.member.id.eq(member.getId())) .then(1).otherwise(0);
+
         List<PostGetListResponseDto> content = queryFactory.select(post)
                 .select(Projections.fields(PostGetListResponseDto.class,
                         post.id.as("postId"),
@@ -86,11 +87,11 @@ public class PostQueryRepositoryImpl implements PostQueryRepository {
                 .fetch();
 
         Long count = queryFactory.select(post.count())
-                .from(post)
-                .where(titleContains(title), categoryEq(categoryCond), post.isDeleted.eq(false))
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
-                .fetchOne();
+                                 .from(post)
+                                 .where(titleContains(title), categoryEq(categoryCond), post.isDeleted.eq(false))
+                                 .offset(pageable.getOffset())
+                                 .limit(pageable.getPageSize())
+                                 .fetchOne();
 
         return new PageImpl<>(content, pageable, count);
     }

--- a/src/main/java/piglin/swapswap/domain/post/repository/PostQueryRepositoryImpl.java
+++ b/src/main/java/piglin/swapswap/domain/post/repository/PostQueryRepositoryImpl.java
@@ -50,6 +50,7 @@ public class PostQueryRepositoryImpl implements PostQueryRepository {
                         favorite.post.count().as("favoriteCnt"),
                         favoriteStatus(member).as("favoriteStatus")))
                 .from(post)
+                .where(isNotDeleted())
                 .distinct()
                 .leftJoin(favorite)
                 .on(favorite.post.eq(post))
@@ -61,6 +62,7 @@ public class PostQueryRepositoryImpl implements PostQueryRepository {
 
         Long count = queryFactory.select(post.count())
                                  .from(post)
+                                 .where(isNotDeleted())
                                  .limit(pageable.getPageSize())
                                  .offset(pageable.getOffset())
                                  .fetchOne();
@@ -85,7 +87,7 @@ public class PostQueryRepositoryImpl implements PostQueryRepository {
                         favoriteStatus(member).as("favoriteStatus")))
                 .distinct()
                 .from(post)
-                .where(titleContains(title), categoryEq(categoryCond))
+                .where(titleContains(title), categoryEq(categoryCond), isNotDeleted())
                 .leftJoin(favorite)
                 .on(favorite.post.eq(post))
                 .groupBy(post.id)
@@ -96,7 +98,7 @@ public class PostQueryRepositoryImpl implements PostQueryRepository {
 
         Long count = queryFactory.select(post.count())
                                  .from(post)
-                                 .where(titleContains(title), categoryEq(categoryCond), post.isDeleted.eq(false))
+                                 .where(titleContains(title), categoryEq(categoryCond), isNotDeleted())
                                  .offset(pageable.getOffset())
                                  .limit(pageable.getPageSize())
                                  .fetchOne();
@@ -110,6 +112,10 @@ public class PostQueryRepositoryImpl implements PostQueryRepository {
 
     private BooleanExpression categoryEq(Category category) {
         return category != null ? post.category.eq(category) : null;
+    }
+
+    private BooleanExpression isNotDeleted() {
+        return post.isDeleted.isFalse();
     }
 
     private BooleanExpression favoriteStatus(Member member) {

--- a/src/main/java/piglin/swapswap/domain/post/repository/PostQueryRepositoryImpl.java
+++ b/src/main/java/piglin/swapswap/domain/post/repository/PostQueryRepositoryImpl.java
@@ -118,7 +118,6 @@ public class PostQueryRepositoryImpl implements PostQueryRepository {
         return new JPAQueryFactory(em).selectOne()
                                       .from(favorite)
                                       .where(favorite.member.id.eq(member.getId()), favorite.post.id.eq(post.id))
-                                      .limit(1)
                                       .exists();
     }
 }

--- a/src/main/java/piglin/swapswap/domain/post/repository/PostQueryRepositoryImpl.java
+++ b/src/main/java/piglin/swapswap/domain/post/repository/PostQueryRepositoryImpl.java
@@ -3,19 +3,25 @@ package piglin.swapswap.domain.post.repository;
 import static piglin.swapswap.domain.favorite.entity.QFavorite.favorite;
 import static piglin.swapswap.domain.post.entity.QPost.post;
 
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.PathBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
+import java.util.ArrayList;
 import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Repository;
 import piglin.swapswap.domain.member.entity.Member;
 import piglin.swapswap.domain.post.constant.Category;
 import piglin.swapswap.domain.post.dto.response.PostGetListResponseDto;
+import piglin.swapswap.domain.post.entity.Post;
 
 @Repository
 public class PostQueryRepositoryImpl implements PostQueryRepository {
@@ -48,6 +54,7 @@ public class PostQueryRepositoryImpl implements PostQueryRepository {
                 .leftJoin(favorite)
                 .on(favorite.post.eq(post))
                 .groupBy(post.id)
+                .orderBy(post.modifiedUpTime.desc(), post.id.desc())
                 .limit(pageable.getPageSize())
                 .offset(pageable.getOffset())
                 .fetch();
@@ -82,6 +89,7 @@ public class PostQueryRepositoryImpl implements PostQueryRepository {
                 .leftJoin(favorite)
                 .on(favorite.post.eq(post))
                 .groupBy(post.id)
+                .orderBy(post.modifiedUpTime.desc(), post.id.desc())
                 .limit(pageable.getPageSize())
                 .offset(pageable.getOffset())
                 .fetch();
@@ -114,6 +122,4 @@ public class PostQueryRepositoryImpl implements PostQueryRepository {
                                       .where(favorite.member.id.eq(member.getId()), favorite.post.id.eq(post.id))
                                       .exists();
     }
-
-
 }

--- a/src/main/java/piglin/swapswap/domain/post/repository/PostQueryRepositoryImpl.java
+++ b/src/main/java/piglin/swapswap/domain/post/repository/PostQueryRepositoryImpl.java
@@ -3,25 +3,19 @@ package piglin.swapswap.domain.post.repository;
 import static piglin.swapswap.domain.favorite.entity.QFavorite.favorite;
 import static piglin.swapswap.domain.post.entity.QPost.post;
 
-import com.querydsl.core.types.Order;
-import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
-import com.querydsl.core.types.dsl.PathBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
-import java.util.ArrayList;
 import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Repository;
 import piglin.swapswap.domain.member.entity.Member;
 import piglin.swapswap.domain.post.constant.Category;
 import piglin.swapswap.domain.post.dto.response.PostGetListResponseDto;
-import piglin.swapswap.domain.post.entity.Post;
 
 @Repository
 public class PostQueryRepositoryImpl implements PostQueryRepository {
@@ -51,7 +45,6 @@ public class PostQueryRepositoryImpl implements PostQueryRepository {
                         favoriteStatus(member).as("favoriteStatus")))
                 .from(post)
                 .where(isNotDeleted())
-                .distinct()
                 .leftJoin(favorite)
                 .on(favorite.post.eq(post))
                 .groupBy(post.id)
@@ -85,7 +78,6 @@ public class PostQueryRepositoryImpl implements PostQueryRepository {
                         post.viewCnt,
                         favorite.post.count().as("favoriteCnt"),
                         favoriteStatus(member).as("favoriteStatus")))
-                .distinct()
                 .from(post)
                 .where(titleContains(title), categoryEq(categoryCond), isNotDeleted())
                 .leftJoin(favorite)
@@ -126,6 +118,7 @@ public class PostQueryRepositoryImpl implements PostQueryRepository {
         return new JPAQueryFactory(em).selectOne()
                                       .from(favorite)
                                       .where(favorite.member.id.eq(member.getId()), favorite.post.id.eq(post.id))
+                                      .limit(1)
                                       .exists();
     }
 }

--- a/src/main/java/piglin/swapswap/domain/post/repository/PostRepository.java
+++ b/src/main/java/piglin/swapswap/domain/post/repository/PostRepository.java
@@ -11,6 +11,4 @@ import piglin.swapswap.domain.post.entity.Post;
 public interface PostRepository extends JpaRepository<Post, Long>, PostQueryRepository {
 
     Optional<Post> findByIdAndIsDeletedIsFalse(Long postId);
-
-    Page<Post> findAllByIsDeletedIsFalse(Pageable pageable);
 }

--- a/src/main/java/piglin/swapswap/domain/post/service/PostServiceImplV1.java
+++ b/src/main/java/piglin/swapswap/domain/post/service/PostServiceImplV1.java
@@ -2,7 +2,6 @@ package piglin.swapswap.domain.post.service;
 
 import jakarta.transaction.Transactional;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -15,7 +14,6 @@ import org.springframework.web.multipart.MultipartFile;
 import piglin.swapswap.domain.favorite.service.FavoriteService;
 import piglin.swapswap.domain.member.entity.Member;
 import piglin.swapswap.domain.post.constant.Category;
-import piglin.swapswap.domain.post.constant.Category.CategoryName;
 import piglin.swapswap.domain.post.constant.PostConstant;
 import piglin.swapswap.domain.post.dto.request.PostCreateRequestDto;
 import piglin.swapswap.domain.post.dto.request.PostUpdateRequestDto;
@@ -198,23 +196,5 @@ public class PostServiceImplV1 implements PostService {
         if (imageUrlList.size() > PostConstant.IMAGE_MAX_SIZE) {
             throw new BusinessException(ErrorCode.POST_IMAGE_MAX_SIZE);
         }
-    }
-
-    private List<PostGetListResponseDto> getPostListResponseDtoWithFavoriteStatus(Member member,
-            Page<Post> postPage) {
-        List<PostGetListResponseDto> responseDtoList = new ArrayList<>();
-
-        for (Post post : postPage) {
-            Long favoriteCnt = favoriteService.getPostFavoriteCnt(post);
-            boolean favoriteStatus = false;
-
-            if (member != null) {
-                favoriteStatus = favoriteService.isFavorite(post, member);
-            }
-
-//            responseDtoList.add(
-//                    PostMapper.postToGetListResponseDto(post, favoriteCnt, favoriteStatus));
-        }
-        return responseDtoList;
     }
 }

--- a/src/main/java/piglin/swapswap/domain/post/service/PostServiceImplV1.java
+++ b/src/main/java/piglin/swapswap/domain/post/service/PostServiceImplV1.java
@@ -86,12 +86,7 @@ public class PostServiceImplV1 implements PostService {
     @Override
     public Page<PostGetListResponseDto> getPostList(Member member, Pageable pageable) {
 
-        Page<Post> postPage = postRepository.findAllByIsDeletedIsFalse(pageable);
-
-        List<PostGetListResponseDto> responseDtoList = getPostListResponseDtoWithFavoriteStatus(
-                member, postPage);
-
-        return PostMapper.toPageDtoList(responseDtoList, pageable, postPage.getTotalElements());
+        return postRepository.findAllPostListWithFavoriteAndPaging(pageable, member);
     }
 
     @Override
@@ -222,8 +217,8 @@ public class PostServiceImplV1 implements PostService {
                 favoriteStatus = favoriteService.isFavorite(post, member);
             }
 
-            responseDtoList.add(
-                    PostMapper.postToGetListResponseDto(post, favoriteCnt, favoriteStatus));
+//            responseDtoList.add(
+//                    PostMapper.postToGetListResponseDto(post, favoriteCnt, favoriteStatus));
         }
         return responseDtoList;
     }

--- a/src/main/java/piglin/swapswap/domain/post/service/PostServiceImplV1.java
+++ b/src/main/java/piglin/swapswap/domain/post/service/PostServiceImplV1.java
@@ -153,12 +153,7 @@ public class PostServiceImplV1 implements PostService {
             categoryCond = Enum.valueOf(Category.class, category);
         }
 
-        Page<Post> postPage = postRepository.searchPost(title, categoryCond, pageable);
-
-        List<PostGetListResponseDto> postListResponseDto = getPostListResponseDtoWithFavoriteStatus(
-                member, postPage);
-
-        return PostMapper.toPageDtoList(postListResponseDto, pageable, postPage.getTotalElements());
+        return postRepository.searchPost(title, categoryCond, member, pageable);
     }
 
     @Override

--- a/src/main/resources/templates/post/postList.html
+++ b/src/main/resources/templates/post/postList.html
@@ -25,22 +25,22 @@
 
   <div class="post-container">
     <div th:each="postDto : ${PostGetListResponseDtoPage.content}" class="post-card">
-      <a th:href="@{/posts/{postId}(postId=${postDto.postId})}">
+      <a th:href="@{/posts/{postId}(postId=${postDto.getPostId})}">
         <div class="post-image-container">
-          <img th:src="${postDto.thumbnailUrl}" alt="Post Image" class="post-image">
+          <img th:src="${postDto.getImageUrl.get(0).toString}" alt="Post Image" class="post-image">
         </div>
-        <h2 th:text="${postDto.title}" class="post-title"></h2>
+        <h2 th:text="${postDto.getTitle}" class="post-title"></h2>
         <div class="post-stats">
-          <span class="view-count">조회수 <span th:text="${postDto.viewCnt}"></span></span>
-          <span class="favorite-count">찜 <span th:text="${postDto.favoriteCnt}"></span></span>
+          <span class="view-count">조회수 <span th:text="${postDto.getViewCnt}"></span></span>
+          <span class="favorite-count">찜 <span th:text="${postDto.getFavoriteCnt}"></span></span>
           <span class="modified-date">올린 날짜 <span
-              th:text="${postDto.modifiedUpTime}"></span></span>
+              th:text="${postDto.getModifiedUpTime}"></span></span>
         </div>
       </a>
       <button
-          th:data-post-id="${postDto.postId}"
+          th:data-post-id="${postDto.getPostId}"
           onclick="toggleFavorite(this.getAttribute('data-post-id'))"
-          th:text="${postDto.favoriteStatus} == true ? '💙' : '🤍'"
+          th:text="${postDto.isFavoriteStatus} == true ? '💙' : '🤍'"
           type="button"
       ></button>
     </div>


### PR DESCRIPTION
## 📝 개요
- [#73 ]
- [#74 ] 
- 에 관한 내용입니다.
<br>

## 👨‍💻 작업 내용
- 기존 Spring Data Jpa 에서 QueryDsl로 바꾸어 N+1 방지 쿼리를 새로 작성하였습니다.
- select 절 서브쿼리를 이용해 로그인 한 사용자의 게시글 좋아요 상태를 확인 할 수 있습니다.
### 수정 전
<img width="1005" alt="스크린샷 2024-01-16 오전 2 16 06" src="https://github.com/Team-Piglin/swapswap/assets/123870616/991c54db-ea77-453c-9e31-b7885f339c01">
<img width="1005" alt="스크린샷 2024-01-16 오전 2 15 28" src="https://github.com/Team-Piglin/swapswap/assets/123870616/b1547589-daf2-4374-9b88-84c2ec64bb0c">


### 수정 후
![스크린샷 2024-01-16 오전 2 27 28](https://github.com/Team-Piglin/swapswap/assets/123870616/cd7c37b8-9195-4e62-a897-29c7eb7056c9)
![스크린샷 2024-01-16 오전 2 26 04](https://github.com/Team-Piglin/swapswap/assets/123870616/b3723bd2-1b71-4e95-8bea-222f455c9710)

포스트 10개 기준 수정 전 지연 시간 86ms에서 수정 후 33ms로 지연 시간이 61.63% 나 줄었습니다
<br>

## 🙇🏻‍♂️ 리뷰어에게
- 꼼꼼히 봐주십쇼 감사합니다 🥲
<br>
