### PR TITLE
Feat: 쿠폰 상세 페이지 및 기능 구현

### DIFF
--- a/src/main/java/piglin/swapswap/domain/coupon/controller/CouponController.java
+++ b/src/main/java/piglin/swapswap/domain/coupon/controller/CouponController.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 import piglin.swapswap.domain.coupon.constant.CouponType;
 import piglin.swapswap.domain.coupon.dto.request.CouponCreateRequestDto;
+import piglin.swapswap.domain.coupon.dto.response.CouponGetResponseDto;
 import piglin.swapswap.domain.coupon.service.CouponService;
 import piglin.swapswap.domain.member.entity.Member;
 import piglin.swapswap.global.annotation.AuthMember;
@@ -53,7 +54,16 @@ public class CouponController {
             return "coupon/createCouponForm";
         }
 
-        return "redirect:/coupon/{couponId}";
+        return "redirect:/coupons/{couponId}";
+    }
+
+    @GetMapping("/{couponId}")
+    public String getCouponDetail(@PathVariable Long couponId, Model model) {
+
+        CouponGetResponseDto couponGetResponseDto = couponService.getCouponDetail(couponId);
+        model.addAttribute("couponGetResponseDto", couponGetResponseDto);
+
+        return "coupon/couponDetail";
     }
 
     @GetMapping("/{couponId}/event")

--- a/src/main/java/piglin/swapswap/domain/coupon/dto/response/CouponGetResponseDto.java
+++ b/src/main/java/piglin/swapswap/domain/coupon/dto/response/CouponGetResponseDto.java
@@ -1,0 +1,16 @@
+package piglin.swapswap.domain.coupon.dto.response;
+
+import java.time.LocalDateTime;
+import lombok.Builder;
+import piglin.swapswap.domain.coupon.constant.CouponType;
+
+@Builder
+public record CouponGetResponseDto(
+        Long couponId,
+        String couponName,
+        CouponType couponType,
+        int discountPercentage,
+        LocalDateTime expiredTime,
+        int couponCount) {
+
+}

--- a/src/main/java/piglin/swapswap/domain/coupon/mapper/CouponMapper.java
+++ b/src/main/java/piglin/swapswap/domain/coupon/mapper/CouponMapper.java
@@ -1,6 +1,7 @@
 package piglin.swapswap.domain.coupon.mapper;
 
 import piglin.swapswap.domain.coupon.dto.request.CouponCreateRequestDto;
+import piglin.swapswap.domain.coupon.dto.response.CouponGetResponseDto;
 import piglin.swapswap.domain.coupon.entity.Coupon;
 
 public class CouponMapper {
@@ -13,6 +14,18 @@ public class CouponMapper {
                 .discountPercentage(couponCreateRequestDto.discountPercentage())
                 .expiredTime(couponCreateRequestDto.expiredTime())
                 .count(couponCreateRequestDto.couponCount())
+                .build();
+    }
+
+    public static CouponGetResponseDto couponToGetResponseDto(Coupon coupon) {
+
+        return CouponGetResponseDto.builder()
+                .couponId(coupon.getId())
+                .couponName(coupon.getName())
+                .couponType(coupon.getCouponType())
+                .discountPercentage(coupon.getDiscountPercentage())
+                .expiredTime(coupon.getExpiredTime())
+                .couponCount(coupon.getCount())
                 .build();
     }
 

--- a/src/main/java/piglin/swapswap/domain/coupon/service/CouponService.java
+++ b/src/main/java/piglin/swapswap/domain/coupon/service/CouponService.java
@@ -1,6 +1,7 @@
 package piglin.swapswap.domain.coupon.service;
 
 import piglin.swapswap.domain.coupon.dto.request.CouponCreateRequestDto;
+import piglin.swapswap.domain.coupon.dto.response.CouponGetResponseDto;
 import piglin.swapswap.domain.member.entity.Member;
 
 public interface CouponService {
@@ -13,4 +14,5 @@ public interface CouponService {
 
     void issueEventCouponByOptimisticLock(Long couponId, Member member);
 
+    CouponGetResponseDto getCouponDetail(Long couponId);
 }

--- a/src/main/java/piglin/swapswap/domain/coupon/service/CouponServiceImplV1.java
+++ b/src/main/java/piglin/swapswap/domain/coupon/service/CouponServiceImplV1.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import piglin.swapswap.domain.coupon.dto.request.CouponCreateRequestDto;
+import piglin.swapswap.domain.coupon.dto.response.CouponGetResponseDto;
 import piglin.swapswap.domain.coupon.entity.Coupon;
 import piglin.swapswap.domain.coupon.mapper.CouponMapper;
 import piglin.swapswap.domain.coupon.repository.CouponRepository;
@@ -73,5 +74,14 @@ public class CouponServiceImplV1 implements CouponService {
     public boolean issueCouponPossible(Coupon coupon) {
 
         return coupon.getCount() > 0;
+    }
+
+    @Override
+    public CouponGetResponseDto getCouponDetail(Long couponId) {
+
+        Coupon coupon = couponRepository.findById(couponId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND_COUPON_EXCEPTION));
+
+        return CouponMapper.couponToGetResponseDto(coupon);
     }
 }

--- a/src/main/resources/templates/coupon/couponDetail.html
+++ b/src/main/resources/templates/coupon/couponDetail.html
@@ -1,0 +1,35 @@
+<!DOCTYPE HTML>
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout=http://www.ultraq.net.nz/thymeleaf/layout
+      layout:decorate="~{common/layout/layout}">
+<body>
+<div layout:fragment="content">
+  <div class="write-bar-container">
+    <div class="write-bar">
+      <div class="write-bar-explain">쿠폰 Id</div>
+      <a class="write-bar-title-input" th:text="${couponGetResponseDto.couponName()}"></a>
+    </div>
+    <div class="write-bar">
+      <div class="write-bar-explain">쿠폰 이름</div>
+      <a class="write-bar-title-input" th:text="${couponGetResponseDto.couponId()}"></a>
+    </div>
+    <div class="write-bar">
+      <div class="write-bar-explain">쿠폰 타입</div>
+      <a class="write-bar-title-input" th:text="${couponGetResponseDto.couponType()}"></a>
+    </div>
+    <div class="write-bar">
+      <div class="write-bar-explain">쿠폰 할인율</div>
+      <a class="write-bar-title-input" th:text="${couponGetResponseDto.discountPercentage()}"></a>
+    </div>
+    <div class="write-bar">
+      <div class="write-bar-explain">쿠폰 만료 기한</div>
+      <a class="write-bar-title-input" th:text="${couponGetResponseDto.expiredTime()}"></a>
+    </div>
+    <div class="write-bar">
+      <div class="write-bar-explain">쿠폰 갯수</div>
+      <a class="write-bar-title-input" th:text="${couponGetResponseDto.couponCount()}"></a>
+    </div>
+  </div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## 📝 개요
- #82 
- 쿠폰을 생성하여 옮겨지거나 url을 직접 입력하여 볼 수 있는 쿠폰 상세 페이지입니다.
<br>

## 👨‍💻 작업 내용
- /coupons/{couponId} URL을 입력하면 해당 쿠폰을 DB에서 조회하여 화면에 출력
<br>

## 🙇🏻‍♂️ 리뷰어에게
- 쿠폰 CRUD는 관리자의 권한이 필요한 기능이기 때문에 쿠폰 발급과 controller를 분리할 계획입니다.
<br>
