### PR TITLE
Refactor: 쿠폰 CRUD 권한을 어드민으로 제한

### DIFF
--- a/src/main/java/piglin/swapswap/domain/coupon/controller/AdminCouponController.java
+++ b/src/main/java/piglin/swapswap/domain/coupon/controller/AdminCouponController.java
@@ -1,0 +1,65 @@
+package piglin.swapswap.domain.coupon.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+import piglin.swapswap.domain.coupon.constant.CouponType;
+import piglin.swapswap.domain.coupon.dto.request.CouponCreateRequestDto;
+import piglin.swapswap.domain.coupon.dto.response.CouponGetResponseDto;
+import piglin.swapswap.domain.coupon.service.CouponService;
+
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("/admin/coupons")
+public class AdminCouponController {
+
+    private final CouponService couponService;
+
+    @GetMapping
+    public String createCouponForm(Model model) {
+
+        model.addAttribute("couponCreateRequestDto", new CouponCreateRequestDto(
+                null, null, 0, null, 0));
+        model.addAttribute("couponType", CouponType.values());
+
+        return "coupon/createCouponForm";
+    }
+
+    @PostMapping
+    public String createCoupon(
+            @Valid @ModelAttribute("couponCreateRequestDto") CouponCreateRequestDto couponCreateRequestDto,
+            BindingResult bindingResult, RedirectAttributes redirectAttributes) {
+
+        if (bindingResult.hasErrors()) {
+            return "coupon/createCouponForm";
+        }
+
+        try {
+            Long couponId = couponService.createCoupon(couponCreateRequestDto);
+            redirectAttributes.addAttribute("couponId", couponId);
+        } catch (Exception e) {
+            bindingResult.reject("쿠폰 등록 중 에러가 발생하였습니다.");
+            return "coupon/createCouponForm";
+        }
+
+        return "redirect:/admin/coupons/{couponId}";
+    }
+
+    @GetMapping("/{couponId}")
+    public String getCouponDetail(@PathVariable Long couponId, Model model) {
+
+        CouponGetResponseDto couponGetResponseDto = couponService.getCouponDetail(couponId);
+        model.addAttribute("couponGetResponseDto", couponGetResponseDto);
+
+        return "coupon/couponDetail";
+    }
+
+}

--- a/src/main/java/piglin/swapswap/domain/coupon/controller/CouponController.java
+++ b/src/main/java/piglin/swapswap/domain/coupon/controller/CouponController.java
@@ -1,21 +1,13 @@
 package piglin.swapswap.domain.coupon.controller;
 
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
-import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
-import org.springframework.web.servlet.mvc.support.RedirectAttributes;
-import piglin.swapswap.domain.coupon.constant.CouponType;
-import piglin.swapswap.domain.coupon.dto.request.CouponCreateRequestDto;
-import piglin.swapswap.domain.coupon.dto.response.CouponGetResponseDto;
 import piglin.swapswap.domain.coupon.service.CouponService;
 import piglin.swapswap.domain.member.entity.Member;
 import piglin.swapswap.global.annotation.AuthMember;
@@ -28,45 +20,6 @@ public class CouponController {
     static final Long EVENT_COUPON_ID = 1L;
 
     private final CouponService couponService;
-
-    @GetMapping
-    public String createCouponForm(Model model) {
-
-        model.addAttribute("couponCreateRequestDto", new CouponCreateRequestDto(
-                null, null, 0, null, 0));
-        model.addAttribute("couponType", CouponType.values());
-
-        return "coupon/createCouponForm";
-    }
-
-    @PostMapping
-    public String createCoupon(
-            @Valid @ModelAttribute("couponCreateRequestDto") CouponCreateRequestDto couponCreateRequestDto,
-            BindingResult bindingResult, RedirectAttributes redirectAttributes) {
-
-        if (bindingResult.hasErrors()) {
-            return "coupon/createCouponForm";
-        }
-
-        try {
-            Long couponId = couponService.createCoupon(couponCreateRequestDto);
-            redirectAttributes.addAttribute("couponId", couponId);
-        } catch (Exception e) {
-            bindingResult.reject("쿠폰 등록 중 에러가 발생하였습니다.");
-            return "coupon/createCouponForm";
-        }
-
-        return "redirect:/coupons/{couponId}";
-    }
-
-    @GetMapping("/{couponId}")
-    public String getCouponDetail(@PathVariable Long couponId, Model model) {
-
-        CouponGetResponseDto couponGetResponseDto = couponService.getCouponDetail(couponId);
-        model.addAttribute("couponGetResponseDto", couponGetResponseDto);
-
-        return "coupon/couponDetail";
-    }
 
     @GetMapping("/event")
     public String couponEvent(Model model) {

--- a/src/main/java/piglin/swapswap/domain/member/constant/MemberRole.java
+++ b/src/main/java/piglin/swapswap/domain/member/constant/MemberRole.java
@@ -3,13 +3,13 @@ package piglin.swapswap.domain.member.constant;
 import lombok.Getter;
 
 @Getter
-public enum MemberRoleEnum {
+public enum MemberRole {
     USER(Authority.USER),
     ADMIN(Authority.ADMIN);
 
     private final String authority;
 
-    MemberRoleEnum(String authority) {
+    MemberRole(String authority) {
         if (authority == null) {
             authority = Authority.USER;
         }
@@ -19,8 +19,8 @@ public enum MemberRoleEnum {
 
     public static class Authority {
 
-        public static final String USER = "USER";
-        public static final String ADMIN = "ADMIN";
+        public static final String USER = "ROLE_USER";
+        public static final String ADMIN = "ROLE_ADMIN";
 
     }
 }

--- a/src/main/java/piglin/swapswap/domain/member/constant/MemberRoleEnum.java
+++ b/src/main/java/piglin/swapswap/domain/member/constant/MemberRoleEnum.java
@@ -19,8 +19,8 @@ public enum MemberRoleEnum {
 
     public static class Authority {
 
-        public static final String USER = "ROLE_USER";
-        public static final String ADMIN = "ROLE_ADMIN";
+        public static final String USER = "USER";
+        public static final String ADMIN = "ADMIN";
 
     }
 }

--- a/src/main/java/piglin/swapswap/domain/member/entity/Member.java
+++ b/src/main/java/piglin/swapswap/domain/member/entity/Member.java
@@ -16,7 +16,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import piglin.swapswap.domain.common.BaseTime;
-import piglin.swapswap.domain.member.constant.MemberRoleEnum;
+import piglin.swapswap.domain.member.constant.MemberRole;
 import piglin.swapswap.domain.wallet.entity.Wallet;
 
 @Entity
@@ -38,7 +38,7 @@ public class Member extends BaseTime {
 
     @Enumerated(value = EnumType.STRING)
     @Column(nullable = false, length = 10)
-    private MemberRoleEnum role;
+    private MemberRole role;
 
     @Column(nullable = false)
     private Boolean isDeleted;

--- a/src/main/java/piglin/swapswap/domain/member/mapper/MemberMapper.java
+++ b/src/main/java/piglin/swapswap/domain/member/mapper/MemberMapper.java
@@ -1,7 +1,6 @@
 package piglin.swapswap.domain.member.mapper;
 
-import java.time.LocalDateTime;
-import piglin.swapswap.domain.member.constant.MemberRoleEnum;
+import piglin.swapswap.domain.member.constant.MemberRole;
 import piglin.swapswap.domain.member.dto.SocialUserInfo;
 import piglin.swapswap.domain.member.entity.Member;
 import piglin.swapswap.domain.wallet.entity.Wallet;
@@ -13,7 +12,7 @@ public class MemberMapper {
         return Member.builder()
                 .email(socialUserInfo.email())
                 .nickname(socialUserInfo.nickname())
-                .role(MemberRoleEnum.USER)
+                .role(MemberRole.USER)
                 .isDeleted(false)
                 .wallet(wallet)
                 .build();

--- a/src/main/java/piglin/swapswap/global/config/WebSecurityConfig.java
+++ b/src/main/java/piglin/swapswap/global/config/WebSecurityConfig.java
@@ -13,6 +13,7 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import piglin.swapswap.domain.member.constant.MemberRoleEnum.Authority;
 import piglin.swapswap.global.jwt.JwtAuthorizationFilter;
 import piglin.swapswap.global.jwt.JwtUtil;
 import piglin.swapswap.global.security.UserDetailsServiceImpl;
@@ -59,6 +60,7 @@ public class WebSecurityConfig {
                         .requestMatchers("/posts/more").permitAll()
                         .requestMatchers("/search/**").permitAll()
                         .requestMatchers("/posts/write").authenticated()
+                        .requestMatchers("/admin/**").hasAuthority(Authority.ADMIN)
                         .anyRequest().authenticated()
         );
 

--- a/src/main/java/piglin/swapswap/global/config/WebSecurityConfig.java
+++ b/src/main/java/piglin/swapswap/global/config/WebSecurityConfig.java
@@ -13,7 +13,7 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-import piglin.swapswap.domain.member.constant.MemberRoleEnum.Authority;
+import piglin.swapswap.domain.member.constant.MemberRole.Authority;
 import piglin.swapswap.global.jwt.JwtAuthorizationFilter;
 import piglin.swapswap.global.jwt.JwtUtil;
 import piglin.swapswap.global.security.UserDetailsServiceImpl;

--- a/src/main/java/piglin/swapswap/global/jwt/JwtUtil.java
+++ b/src/main/java/piglin/swapswap/global/jwt/JwtUtil.java
@@ -24,7 +24,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
-import piglin.swapswap.domain.member.constant.MemberRoleEnum;
+import piglin.swapswap.domain.member.constant.MemberRole;
 
 @Component
 public class JwtUtil {
@@ -49,7 +49,7 @@ public class JwtUtil {
         key = Keys.hmacShaKeyFor(bytes);
     }
 
-    public String createToken(String email, MemberRoleEnum role) {
+    public String createToken(String email, MemberRole role) {
 
         Map<String, Object> headers = new HashMap<>();
         headers.put("typ", "JWT");

--- a/src/main/java/piglin/swapswap/global/security/UserDetailsImpl.java
+++ b/src/main/java/piglin/swapswap/global/security/UserDetailsImpl.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
-import piglin.swapswap.domain.member.constant.MemberRoleEnum;
+import piglin.swapswap.domain.member.constant.MemberRole;
 import piglin.swapswap.domain.member.entity.Member;
 
 @Getter
@@ -38,7 +38,7 @@ public class UserDetailsImpl implements UserDetails {
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        MemberRoleEnum role = member.getRole();
+        MemberRole role = member.getRole();
         String authority = role.getAuthority();
 
         SimpleGrantedAuthority simpleGrantedAuthority = new SimpleGrantedAuthority(authority);

--- a/src/main/resources/templates/coupon/createCouponForm.html
+++ b/src/main/resources/templates/coupon/createCouponForm.html
@@ -17,7 +17,7 @@
       event.target.classList.add('active')
     }
   </script>
-  <form th:action="@{/coupons}" th:object="${couponCreateRequestDto}" method="post"
+  <form th:action="@{/admin/coupons}" th:object="${couponCreateRequestDto}" method="post"
         enctype="application/x-www-form-urlencoded">
     <div class="write-bar-container">
       <div class="write-bar">

--- a/src/main/resources/templates/coupon/issueEventCoupon.html
+++ b/src/main/resources/templates/coupon/issueEventCoupon.html
@@ -5,14 +5,17 @@
 <body>
 <div layout:fragment="content">
   <div class="extra-coupon">
-  <img class="coupon-event-img" src="/images/eventcouponimage.png">
+    <img class="coupon-event-img" src="/images/eventcouponimage.png">
   </div>
   <p class="extra-coupon">남은 쿠폰 개수 <span th:text="${couponCount}"></span></p>
   <div class="extra-coupon">
-  <button class="coupon-issue-btn" th:if="${couponCount > 0}" onclick="claimCoupon()">쿠폰 받기</button>
+    <button class="coupon-issue-btn" th:if="${couponCount > 0}" onclick="claimCoupon()">쿠폰 받기
+    </button>
   </div>
   <div th:unless="${couponCount > 0}">
-    <p>쿠폰이 모두 소진되었습니다.</p>
+    <div class="extra-coupon">
+      <p>쿠폰이 모두 소진되었습니다.</p>
+    </div>
   </div>
 </div>
 </body>

--- a/src/test/java/piglin/swapswap/domain/coupon/service/CouponServiceTest.java
+++ b/src/test/java/piglin/swapswap/domain/coupon/service/CouponServiceTest.java
@@ -14,7 +14,7 @@ import piglin.swapswap.domain.coupon.constant.CouponType;
 import piglin.swapswap.domain.coupon.dto.request.CouponCreateRequestDto;
 import piglin.swapswap.domain.coupon.entity.Coupon;
 import piglin.swapswap.domain.coupon.repository.CouponRepository;
-import piglin.swapswap.domain.member.constant.MemberRoleEnum;
+import piglin.swapswap.domain.member.constant.MemberRole;
 import piglin.swapswap.domain.member.entity.Member;
 import piglin.swapswap.domain.member.repository.MemberRepository;
 import piglin.swapswap.domain.membercoupon.service.MemberCouponService;
@@ -66,7 +66,7 @@ class CouponServiceTest {
         member = Member.builder()
                 .email("yeowuli2@naver.com")
                 .nickname("손창현")
-                .role(MemberRoleEnum.USER)
+                .role(MemberRole.USER)
                 .isDeleted(false)
                 .wallet(wallet)
                 .build();


### PR DESCRIPTION
쿠폰을 CRUD할 수 있는 권한을 어드민으로 제한

## 📝 개요
- 쿠폰 CRUD 권한 어드민으로 제한
<br>

## 👨‍💻 작업 내용
- 쿠폰 CRUD를 위한 어드민 전용 컨트롤러와 쿠폰 발급을 위한 일반 유저용 컨트롤러로 구분하였습니다.
- 쿠폰 CRUD의 권한을 어드민으로 제한하였습니다.
- MemberRoleEnum의 필드 값을 각각 ROLE_USER -> USER, ROLE_ADMIN -> ADMIN으로 변경하였습니다.
<br>

## 🙇🏻‍♂️ 리뷰어에게
- 컨트롤러단에서 권한 제한을 할 수 있지만 권한 제한에 대한 내용을 한 곳에서 볼 수 있게 하기 위해 WebSecurityConfig에 선언하였습니다.
<br>
