### PR TITLE
refactor: 게시글 리스트 조회 매핑방식 fields -> constructor

### DIFF
--- a/src/main/java/piglin/swapswap/domain/post/dto/response/PostGetListResponseDto.java
+++ b/src/main/java/piglin/swapswap/domain/post/dto/response/PostGetListResponseDto.java
@@ -5,23 +5,22 @@ import java.util.Map;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Getter
-@NoArgsConstructor
-public class PostGetListResponseDto {
+public record PostGetListResponseDto(
+        Long postId,
 
-    Long postId;
+        Long memberId,
 
-    Long memberId;
+        String title,
 
-    String title;
+        Map<Integer, Object> imageUrl,
 
-    Map<Integer, Object> imageUrl;
+        LocalDateTime modifiedUpTime,
 
-    LocalDateTime modifiedUpTime;
+        Long viewCnt,
 
-    Long viewCnt;
+        Long favoriteCnt,
 
-    Long favoriteCnt;
+        boolean favoriteStatus
+) {
 
-    boolean favoriteStatus;
 }

--- a/src/main/java/piglin/swapswap/domain/post/repository/PostQueryRepositoryImpl.java
+++ b/src/main/java/piglin/swapswap/domain/post/repository/PostQueryRepositoryImpl.java
@@ -32,15 +32,15 @@ public class PostQueryRepositoryImpl implements PostQueryRepository {
             Member member, LocalDateTime cursorTime) {
 
         return queryFactory
-                .select(Projections.fields(PostGetListResponseDto.class,
-                        post.id.as("postId"),
-                        post.member.id.as("memberId"),
+                .select(Projections.constructor(PostGetListResponseDto.class,
+                        post.id,
+                        post.member.id,
                         post.title,
                         post.imageUrl,
                         post.modifiedUpTime,
                         post.viewCnt,
-                        favorite.post.count().as("favoriteCnt"),
-                        favoriteStatus(member).as("favoriteStatus")))
+                        favorite.post.count(),
+                        favoriteStatus(member)))
                 .from(post)
                 .where(isNotDeleted(), lessThanCursorTime(cursorTime))
                 .leftJoin(favorite)
@@ -57,15 +57,15 @@ public class PostQueryRepositoryImpl implements PostQueryRepository {
             Member member, LocalDateTime cursorTime) {
 
         return queryFactory.select(post)
-                .select(Projections.fields(PostGetListResponseDto.class,
-                        post.id.as("postId"),
-                        post.member.id.as("memberId"),
+                .select(Projections.constructor(PostGetListResponseDto.class,
+                        post.id,
+                        post.member.id,
                         post.title,
                         post.imageUrl,
                         post.modifiedUpTime,
                         post.viewCnt,
-                        favorite.post.count().as("favoriteCnt"),
-                        favoriteStatus(member).as("favoriteStatus")))
+                        favorite.post.count(),
+                        favoriteStatus(member)))
                 .from(post)
                 .where(titleContains(titleCond), categoryEq(categoryCond), isNotDeleted(),
                         lessThanCursorTime(cursorTime))

--- a/src/main/resources/templates/post/postList.html
+++ b/src/main/resources/templates/post/postList.html
@@ -24,23 +24,23 @@
   </div>
   <div class="post-container">
     <div th:each="postDto : ${PostGetListResponseDto}" class="post-card"
-         th:data-modified-time="${postDto.getModifiedUpTime}">
-      <a th:href="@{/posts/{postId}(postId=${postDto.getPostId})}">
+         th:data-modified-time="${postDto.modifiedUpTime}">
+      <a th:href="@{/posts/{postId}(postId=${postDto.postId})}">
         <div class="post-image-container">
-          <img th:src="${postDto.getImageUrl.get(0).toString}" alt="Post Image" class="post-image">
+          <img th:src="${postDto.imageUrl.get(0).toString}" alt="Post Image" class="post-image">
         </div>
-        <h2 th:text="${postDto.getTitle}" class="post-title"></h2>
+        <h2 th:text="${postDto.title}" class="post-title"></h2>
         <div class="post-stats">
-          <span class="view-count">조회수 <span th:text="${postDto.getViewCnt}"></span></span>
-          <span class="favorite-count">찜 <span th:text="${postDto.getFavoriteCnt}"></span></span>
+          <span class="view-count">조회수 <span th:text="${postDto.viewCnt}"></span></span>
+          <span class="favorite-count">찜 <span th:text="${postDto.favoriteCnt}"></span></span>
           <span class="modified-date">올린 날짜 <span
-              th:text="${postDto.getModifiedUpTime}"></span></span>
+              th:text="${postDto.modifiedUpTime}"></span></span>
         </div>
       </a>
       <button
-          th:data-post-id="${postDto.getPostId}"
+          th:data-post-id="${postDto.postId}"
           onclick="toggleFavorite(this.getAttribute('data-post-id'))"
-          th:text="${postDto.isFavoriteStatus} == true ? '💙' : '🤍'"
+          th:text="${postDto.favoriteStatus} == true ? '💙' : '🤍'"
           type="button"
       ></button>
     </div>

--- a/src/main/resources/templates/post/postListFragment.html
+++ b/src/main/resources/templates/post/postListFragment.html
@@ -2,23 +2,23 @@
 <html xmlns:th="http://www.thymeleaf.org">
 <body>
   <div th:each="postDto : ${PostGetListResponseDto}" class="post-card"
-       th:data-modified-time="${postDto.getModifiedUpTime}">
-    <a th:href="@{/posts/{postId}(postId=${postDto.getPostId})}">
+       th:data-modified-time="${postDto.modifiedUpTime}">
+    <a th:href="@{/posts/{postId}(postId=${postDto.postId})}">
       <div class="post-image-container">
-        <img th:src="${postDto.getImageUrl.get(0).toString}" alt="Post Image" class="post-image">
+        <img th:src="${postDto.imageUrl.get(0).toString}" alt="Post Image" class="post-image">
       </div>
-      <h2 th:text="${postDto.getTitle}" class="post-title"></h2>
+      <h2 th:text="${postDto.title}" class="post-title"></h2>
       <div class="post-stats">
-        <span class="view-count">조회수 <span th:text="${postDto.getViewCnt}"></span></span>
-        <span class="favorite-count">찜 <span th:text="${postDto.getFavoriteCnt}"></span></span>
+        <span class="view-count">조회수 <span th:text="${postDto.viewCnt}"></span></span>
+        <span class="favorite-count">찜 <span th:text="${postDto.favoriteCnt}"></span></span>
         <span class="modified-date">올린 날짜 <span
-            th:text="${postDto.getModifiedUpTime}"></span></span>
+            th:text="${postDto.modifiedUpTime}"></span></span>
       </div>
     </a>
     <button
-        th:data-post-id="${postDto.getPostId}"
+        th:data-post-id="${postDto.postId}"
         onclick="toggleFavorite(this.getAttribute('data-post-id'))"
-        th:text="${postDto.isFavoriteStatus} == true ? '💙' : '🤍'"
+        th:text="${postDto.favoriteStatus} == true ? '💙' : '🤍'"
         type="button"
     ></button>
   </div>

--- a/src/main/resources/templates/post/postSearchList.html
+++ b/src/main/resources/templates/post/postSearchList.html
@@ -24,23 +24,23 @@
   </div>
   <div class="post-container">
     <div th:each="postDto : ${PostGetListResponseDto}" class="post-card"
-         th:data-modified-time="${postDto.getModifiedUpTime}">
-      <a th:href="@{/posts/{postId}(postId=${postDto.getPostId})}">
+         th:data-modified-time="${postDto.modifiedUpTime}">
+      <a th:href="@{/posts/{postId}(postId=${postDto.postId})}">
         <div class="post-image-container">
-          <img th:src="${postDto.getImageUrl.get(0).toString}" alt="Post Image" class="post-image">
+          <img th:src="${postDto.imageUrl.get(0).toString}" alt="Post Image" class="post-image">
         </div>
-        <h2 th:text="${postDto.getTitle}" class="post-title"></h2>
+        <h2 th:text="${postDto.title}" class="post-title"></h2>
         <div class="post-stats">
-          <span class="view-count">조회수 <span th:text="${postDto.getViewCnt}"></span></span>
-          <span class="favorite-count">찜 <span th:text="${postDto.getFavoriteCnt}"></span></span>
+          <span class="view-count">조회수 <span th:text="${postDto.viewCnt}"></span></span>
+          <span class="favorite-count">찜 <span th:text="${postDto.favoriteCnt}"></span></span>
           <span class="modified-date">올린 날짜 <span
-              th:text="${postDto.getModifiedUpTime}"></span></span>
+              th:text="${postDto.modifiedUpTime}"></span></span>
         </div>
       </a>
       <button
-          th:data-post-id="${postDto.getPostId}"
+          th:data-post-id="${postDto.postId}"
           onclick="toggleFavorite(this.getAttribute('data-post-id'))"
-          th:text="${postDto.isFavoriteStatus} == true ? '💙' : '🤍'"
+          th:text="${postDto.favoriteStatus} == true ? '💙' : '🤍'"
           type="button"
       ></button>
     </div>


### PR DESCRIPTION
## 📝 개요
- 기존 QueryDsl 에서 Projections.fileds 방법이랑.. @QueryProjection 등만 있는 것만 기억났었는데 게시글 단건 조회에서 constructor 방법 있는 거 기억나서 다시 수정했습니다!
<br>

## 👨‍💻 작업 내용
- 게시글 리스트 조회 매핑방식 fields -> constructor / 이에 따른 PostGetListResponseDto record 클래스로 재 수정 / alias 삭제
<br>

## 🙇🏻‍♂️ 리뷰어에게
- 수정한 부분 많이 없고, 실수한 부분있을 수 있으니 쬐끔 자세히 봐주세요~~
<br>
