### PR TITLE
Feature: 지갑 입금 페이지 및 기능 구현

### DIFF
--- a/src/main/java/piglin/swapswap/domain/member/repository/MemberQueryRepository.java
+++ b/src/main/java/piglin/swapswap/domain/member/repository/MemberQueryRepository.java
@@ -1,0 +1,10 @@
+package piglin.swapswap.domain.member.repository;
+
+import java.util.Optional;
+import piglin.swapswap.domain.member.entity.Member;
+
+public interface MemberQueryRepository {
+
+    Optional<Member> findByIdWithWallet(Long memberId);
+
+}

--- a/src/main/java/piglin/swapswap/domain/member/repository/MemberQueryRepositoryImpl.java
+++ b/src/main/java/piglin/swapswap/domain/member/repository/MemberQueryRepositoryImpl.java
@@ -1,0 +1,43 @@
+package piglin.swapswap.domain.member.repository;
+
+import static piglin.swapswap.domain.member.entity.QMember.member;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import java.util.Optional;
+import piglin.swapswap.domain.member.entity.Member;
+import piglin.swapswap.domain.wallet.entity.QWallet;
+
+public class MemberQueryRepositoryImpl implements MemberQueryRepository {
+
+    private final EntityManager em;
+
+    private final JPAQueryFactory queryFactory;
+
+    public MemberQueryRepositoryImpl(EntityManager em) {
+        this.em = em;
+        this.queryFactory = new JPAQueryFactory(em);
+    }
+
+    @Override
+    public Optional<Member> findByIdWithWallet(Long memberId) {
+        return Optional.ofNullable(
+                queryFactory
+                        .selectFrom(member)
+                        .join(member.wallet, QWallet.wallet)
+                        .fetchJoin()
+                        .where(memberIdEq(memberId), isNotDeleted())
+                        .fetchOne());
+    }
+
+    private BooleanExpression memberIdEq(Long memberId) {
+
+        return member.id.eq(memberId);
+    }
+
+    private BooleanExpression isNotDeleted() {
+
+        return member.isDeleted.isFalse();
+    }
+}

--- a/src/main/java/piglin/swapswap/domain/member/repository/MemberRepository.java
+++ b/src/main/java/piglin/swapswap/domain/member/repository/MemberRepository.java
@@ -7,7 +7,7 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import piglin.swapswap.domain.member.entity.Member;
 
-public interface MemberRepository extends JpaRepository<Member, Long> {
+public interface MemberRepository extends JpaRepository<Member, Long>, MemberQueryRepository {
 
 
     Optional<Member> findByEmailAndIsDeletedIsFalse(String Email);

--- a/src/main/java/piglin/swapswap/domain/member/service/KakaoServiceImpl.java
+++ b/src/main/java/piglin/swapswap/domain/member/service/KakaoServiceImpl.java
@@ -20,7 +20,7 @@ import piglin.swapswap.domain.member.entity.Member;
 import piglin.swapswap.domain.member.mapper.MemberMapper;
 import piglin.swapswap.domain.member.repository.MemberRepository;
 import piglin.swapswap.domain.wallet.entity.Wallet;
-import piglin.swapswap.domain.wallet.repository.WalletRepository;
+import piglin.swapswap.domain.wallet.service.WalletService;
 import piglin.swapswap.global.jwt.JwtUtil;
 
 @Service
@@ -28,7 +28,7 @@ import piglin.swapswap.global.jwt.JwtUtil;
 @Log4j2
 public class KakaoServiceImpl implements SocialService {
 
-    private final WalletRepository walletRepository;
+    private final WalletService walletService;
     private final MemberRepository memberRepository;
     private final RestTemplate restTemplate;
     private final JwtUtil jwtUtil;
@@ -129,7 +129,7 @@ public class KakaoServiceImpl implements SocialService {
                     return existingMember;
                 })
                 .orElseGet(() -> {
-                    Wallet savedWallet = walletRepository.save(Wallet.builder().money(0L).build());
+                    Wallet savedWallet = walletService.createWallet();
                     return memberRepository.save(
                             MemberMapper.createMember(kakaoUserInfo, savedWallet));
                 });

--- a/src/main/java/piglin/swapswap/domain/member/service/MemberService.java
+++ b/src/main/java/piglin/swapswap/domain/member/service/MemberService.java
@@ -9,6 +9,8 @@ public interface MemberService {
 
     void deleteMember(Member loginMember);
 
-    Long getMySwapMoney(Long member);
+    Long getMySwapMoney(Long memberId);
+
+    Member getMemberWithWallet(Long memberId);
 
 }

--- a/src/main/java/piglin/swapswap/domain/member/service/MemberServiceImplV1.java
+++ b/src/main/java/piglin/swapswap/domain/member/service/MemberServiceImplV1.java
@@ -11,7 +11,7 @@ import piglin.swapswap.global.exception.common.ErrorCode;
 
 @Service
 @RequiredArgsConstructor
-public class MemberServiceImpl implements MemberService {
+public class MemberServiceImplV1 implements MemberService {
 
     private final MemberRepository memberRepository;
 
@@ -44,12 +44,14 @@ public class MemberServiceImpl implements MemberService {
     @Transactional
     public Long getMySwapMoney(Long memberId) {
 
-        Member member = memberRepository.findByIdAndIsDeletedIsFalse(memberId).orElseThrow(
-                () -> new BusinessException(ErrorCode.NOT_FOUND_USER_EXCEPTION)
-        );
+        Member member = getMemberWithWallet(memberId);
 
-        return member.getWallet().getMoney();
+        return member.getWallet().getSwapMoney();
     }
 
-
+    @Override
+    public Member getMemberWithWallet(Long memberId) {
+        return memberRepository.findByIdWithWallet(memberId).orElseThrow(
+                () -> new BusinessException(ErrorCode.NOT_FOUND_USER_EXCEPTION));
+    }
 }

--- a/src/main/java/piglin/swapswap/domain/wallet/controller/WalletController.java
+++ b/src/main/java/piglin/swapswap/domain/wallet/controller/WalletController.java
@@ -35,7 +35,7 @@ public class WalletController {
             DepositSwapMoneyRequestDto depositSwapMoneyRequestDto,
             @AuthMember Member member) {
 
-        walletService.depositSwapMoney(depositSwapMoneyRequestDto.swapMoney(), member.getId());
+        walletService.noramlDepositSwapMoney(depositSwapMoneyRequestDto.swapMoney(), member.getId());
 
         return "redirect:/members/swap-money";
     }

--- a/src/main/java/piglin/swapswap/domain/wallet/controller/WalletController.java
+++ b/src/main/java/piglin/swapswap/domain/wallet/controller/WalletController.java
@@ -1,0 +1,42 @@
+package piglin.swapswap.domain.wallet.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import piglin.swapswap.domain.member.entity.Member;
+import piglin.swapswap.domain.wallet.dto.request.DepositSwapMoneyRequestDto;
+import piglin.swapswap.domain.wallet.service.WalletService;
+import piglin.swapswap.global.annotation.AuthMember;
+
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("/wallets")
+public class WalletController {
+
+    private final WalletService walletService;
+
+    @GetMapping("/deposit")
+    public String showDepositSwapMoneyPage(Model model) {
+
+        model.addAttribute("depositSwapMoneyRequestDto",
+                new DepositSwapMoneyRequestDto(null));
+
+        return "wallet/depositSwapMoney";
+    }
+
+    @PostMapping("/deposit")
+    public String depositSwapMoney(
+            @Valid @ModelAttribute("depositSwapMoneyRequestDto")
+            DepositSwapMoneyRequestDto depositSwapMoneyRequestDto,
+            @AuthMember Member member) {
+
+        walletService.depositSwapMoney(depositSwapMoneyRequestDto.swapMoney(), member.getId());
+
+        return "redirect:/members/swap-money";
+    }
+}

--- a/src/main/java/piglin/swapswap/domain/wallet/dto/request/DepositSwapMoneyRequestDto.java
+++ b/src/main/java/piglin/swapswap/domain/wallet/dto/request/DepositSwapMoneyRequestDto.java
@@ -1,0 +1,7 @@
+package piglin.swapswap.domain.wallet.dto.request;
+
+import jakarta.validation.constraints.Positive;
+
+public record DepositSwapMoneyRequestDto(@Positive Long swapMoney) {
+
+}

--- a/src/main/java/piglin/swapswap/domain/wallet/entity/Wallet.java
+++ b/src/main/java/piglin/swapswap/domain/wallet/entity/Wallet.java
@@ -5,15 +5,12 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.OneToMany;
-import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import piglin.swapswap.domain.common.BaseTime;
-import piglin.swapswap.domain.wallethistory.entity.WalletHistory;
 
 @Entity
 @Builder
@@ -27,9 +24,21 @@ public class Wallet extends BaseTime {
     private Long id;
 
     @Column(nullable = false)
-    private Long money;
+    private Long swapMoney;
 
-    // TODO 지워도 ㅗ딜것같음
-    @OneToMany(mappedBy = "wallet")
-    private List<WalletHistory> walletHistoryList;
+    @Column(nullable = false)
+    private boolean isDeleted;
+
+    public void depositSwapMoney(Long depositSwapMoney) {
+
+        swapMoney += depositSwapMoney;
+    }
+
+    public static Wallet createWallet() {
+        return Wallet.builder()
+                .swapMoney(0L)
+                .isDeleted(false)
+                .build();
+    }
+
 }

--- a/src/main/java/piglin/swapswap/domain/wallet/service/WalletService.java
+++ b/src/main/java/piglin/swapswap/domain/wallet/service/WalletService.java
@@ -1,0 +1,9 @@
+package piglin.swapswap.domain.wallet.service;
+
+import piglin.swapswap.domain.wallet.entity.Wallet;
+
+public interface WalletService {
+
+    Wallet createWallet();
+    void depositSwapMoney(Long swapMoney, Long member);
+}

--- a/src/main/java/piglin/swapswap/domain/wallet/service/WalletService.java
+++ b/src/main/java/piglin/swapswap/domain/wallet/service/WalletService.java
@@ -5,5 +5,5 @@ import piglin.swapswap.domain.wallet.entity.Wallet;
 public interface WalletService {
 
     Wallet createWallet();
-    void depositSwapMoney(Long swapMoney, Long member);
+    void noramlDepositSwapMoney(Long swapMoney, Long member);
 }

--- a/src/main/java/piglin/swapswap/domain/wallet/service/WalletServiceImplV1.java
+++ b/src/main/java/piglin/swapswap/domain/wallet/service/WalletServiceImplV1.java
@@ -1,0 +1,49 @@
+package piglin.swapswap.domain.wallet.service;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import piglin.swapswap.domain.member.entity.Member;
+import piglin.swapswap.domain.member.service.MemberService;
+import piglin.swapswap.domain.wallet.entity.Wallet;
+import piglin.swapswap.domain.wallet.repository.WalletRepository;
+import piglin.swapswap.domain.wallethistory.constant.HistoryType;
+import piglin.swapswap.domain.wallethistory.entity.WalletHistory;
+import piglin.swapswap.domain.wallethistory.mapper.WalletHistoryMapper;
+import piglin.swapswap.domain.wallethistory.service.WalletHistoryService;
+
+@Service
+@RequiredArgsConstructor
+public class WalletServiceImplV1 implements WalletService {
+
+    private final WalletRepository walletRepository;
+
+    private final WalletHistoryService walletHistoryService;
+
+    private final MemberService memberService;
+
+
+    @Override
+    public Wallet createWallet() {
+
+        return walletRepository.save(Wallet.createWallet());
+    }
+
+    @Override
+    @Transactional
+    public void depositSwapMoney(Long swapMoney, Long memberId) {
+
+        Member member = memberService.getMemberWithWallet(memberId);
+
+        Wallet wallet = member.getWallet();
+        wallet.depositSwapMoney(swapMoney);
+
+        recordWalletHistory(swapMoney, HistoryType.NORMAL_DEPOSIT);
+    }
+
+    private void recordWalletHistory(Long swapMoney, HistoryType historyType) {
+
+        WalletHistory walletHistory = WalletHistoryMapper.createWalletHistory(swapMoney, historyType);
+        walletHistoryService.recordWalletHistory(walletHistory);
+    }
+}

--- a/src/main/java/piglin/swapswap/domain/wallet/service/WalletServiceImplV1.java
+++ b/src/main/java/piglin/swapswap/domain/wallet/service/WalletServiceImplV1.java
@@ -31,14 +31,14 @@ public class WalletServiceImplV1 implements WalletService {
 
     @Override
     @Transactional
-    public void depositSwapMoney(Long swapMoney, Long memberId) {
+    public void noramlDepositSwapMoney(Long depositSwapMoney, Long memberId) {
 
         Member member = memberService.getMemberWithWallet(memberId);
 
         Wallet wallet = member.getWallet();
-        wallet.depositSwapMoney(swapMoney);
+        wallet.depositSwapMoney(depositSwapMoney);
 
-        recordWalletHistory(swapMoney, HistoryType.NORMAL_DEPOSIT);
+        recordWalletHistory(depositSwapMoney, HistoryType.NORMAL_DEPOSIT);
     }
 
     private void recordWalletHistory(Long swapMoney, HistoryType historyType) {

--- a/src/main/java/piglin/swapswap/domain/wallethistory/constant/HistoryType.java
+++ b/src/main/java/piglin/swapswap/domain/wallethistory/constant/HistoryType.java
@@ -1,5 +1,23 @@
 package piglin.swapswap.domain.wallethistory.constant;
 
 public enum HistoryType {
-    NORMAL_DEPOSIT, NORMAL_WITHDRAW, DEAL_DEPOSIT, DEAL_WITHDRAW
+
+    NORMAL_DEPOSIT(HistoryTypeName.NORMAL_DEPOSIT),
+    NORMAL_WITHDRAW(HistoryTypeName.NORMAL_WITHDRAW),
+    DEAL_DEPOSIT(HistoryTypeName.DEAL_DEPOSIT),
+    DEAL_WITHDRAW(HistoryTypeName.DEAL_WITHDRAW);
+    
+    private final String name;
+
+    HistoryType(String name) {
+        this.name = name;
+    }
+
+    public static class HistoryTypeName {
+        public static String NORMAL_DEPOSIT = "일반 입금";
+        public static String NORMAL_WITHDRAW = "일반 출금";
+        public static String DEAL_DEPOSIT = "거래 입금";
+        public static String DEAL_WITHDRAW = "거래 출금";
+    } 
+    
 }

--- a/src/main/java/piglin/swapswap/domain/wallethistory/constant/HistoryType.java
+++ b/src/main/java/piglin/swapswap/domain/wallethistory/constant/HistoryType.java
@@ -1,0 +1,5 @@
+package piglin.swapswap.domain.wallethistory.constant;
+
+public enum HistoryType {
+    NORMAL_DEPOSIT, NORMAL_WITHDRAW, DEAL_DEPOSIT, DEAL_WITHDRAW
+}

--- a/src/main/java/piglin/swapswap/domain/wallethistory/entity/WalletHistory.java
+++ b/src/main/java/piglin/swapswap/domain/wallethistory/entity/WalletHistory.java
@@ -2,12 +2,13 @@ package piglin.swapswap.domain.wallethistory.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -15,6 +16,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import piglin.swapswap.domain.common.BaseTime;
 import piglin.swapswap.domain.wallet.entity.Wallet;
+import piglin.swapswap.domain.wallethistory.constant.HistoryType;
 
 @Entity
 @Builder
@@ -27,13 +29,18 @@ public class WalletHistory extends BaseTime {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column
-    private LocalDateTime depositTime;
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private HistoryType historyType;
 
-    @Column
-    private LocalDateTime withdrawTime;
+    @Column(nullable = false)
+    private Long swapMoney;
 
     @ManyToOne
     @JoinColumn(name = "wallet_id")
     private Wallet wallet;
+
+    @Column(nullable = false)
+    private boolean isDeleted;
+
 }

--- a/src/main/java/piglin/swapswap/domain/wallethistory/mapper/WalletHistoryMapper.java
+++ b/src/main/java/piglin/swapswap/domain/wallethistory/mapper/WalletHistoryMapper.java
@@ -1,0 +1,17 @@
+package piglin.swapswap.domain.wallethistory.mapper;
+
+import piglin.swapswap.domain.wallethistory.constant.HistoryType;
+import piglin.swapswap.domain.wallethistory.entity.WalletHistory;
+
+public class WalletHistoryMapper {
+
+    public static WalletHistory createWalletHistory(Long swapMoney, HistoryType historyType) {
+
+        return WalletHistory.builder()
+                .historyType(historyType)
+                .swapMoney(swapMoney)
+                .isDeleted(false)
+                .build();
+    }
+
+}

--- a/src/main/java/piglin/swapswap/domain/wallethistory/repository/WalletHistoryRepository.java
+++ b/src/main/java/piglin/swapswap/domain/wallethistory/repository/WalletHistoryRepository.java
@@ -1,0 +1,8 @@
+package piglin.swapswap.domain.wallethistory.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import piglin.swapswap.domain.wallethistory.entity.WalletHistory;
+
+public interface WalletHistoryRepository extends JpaRepository<WalletHistory, Long> {
+
+}

--- a/src/main/java/piglin/swapswap/domain/wallethistory/service/WalletHistoryService.java
+++ b/src/main/java/piglin/swapswap/domain/wallethistory/service/WalletHistoryService.java
@@ -1,0 +1,9 @@
+package piglin.swapswap.domain.wallethistory.service;
+
+import piglin.swapswap.domain.wallethistory.entity.WalletHistory;
+
+public interface WalletHistoryService {
+
+    void recordWalletHistory(WalletHistory walletHistory);
+
+}

--- a/src/main/java/piglin/swapswap/domain/wallethistory/service/WalletHistoryServiceImplV1.java
+++ b/src/main/java/piglin/swapswap/domain/wallethistory/service/WalletHistoryServiceImplV1.java
@@ -1,0 +1,18 @@
+package piglin.swapswap.domain.wallethistory.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import piglin.swapswap.domain.wallethistory.entity.WalletHistory;
+import piglin.swapswap.domain.wallethistory.repository.WalletHistoryRepository;
+
+@Service
+@RequiredArgsConstructor
+public class WalletHistoryServiceImplV1 implements WalletHistoryService {
+
+    private final WalletHistoryRepository walletHistoryRepository;
+
+    @Override
+    public void recordWalletHistory(WalletHistory walletHistory) {
+        walletHistoryRepository.save(walletHistory);
+    }
+}

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -1129,3 +1129,29 @@ input[type="number"] {
 .withdraw-btn {
   background: url("/images/withdraw.jpg") no-repeat;
 }
+
+.swap-money-input {
+  width: 300px;
+  height: 50px;
+  border-top: none;
+  border-left: none;
+  border-right: none;
+  border-bottom: 3px solid;
+}
+
+.deposit-swap-money-btn {
+  width: 100px;
+  height: 50px;
+  border-top: none;
+  border-left: none;
+  border-right: none;
+  border-bottom: none;
+  border-radius: 5px;
+  background-color: #00AADC;
+}
+
+.deposit-swap-money-btn:hover {
+  background-color: #171264;
+  color: white;
+  transition: 0.7s;
+}

--- a/src/main/resources/templates/wallet/depositSwapMoney.html
+++ b/src/main/resources/templates/wallet/depositSwapMoney.html
@@ -1,0 +1,16 @@
+<!DOCTYPE HTML>
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout=http://www.ultraq.net.nz/thymeleaf/layout
+      layout:decorate="~{common/layout/layout}">
+<body>
+<div layout:fragment="content">
+  <div class="swap-money-body">
+    <p>얼마를 충전하시겠습니까?</p>
+    <form th:action="@{/wallets/deposit}" th:object="${depositSwapMoneyRequestDto}" method="post" enctype="application/x-www-form-urlencoded">
+      <input class="swap-money-input" th:field="*{swapMoney}">
+      <button type="submit" class="deposit-swap-money-btn">입금하기</button>
+    </form>
+  </div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## 📝 개요
- 지갑에 스왑머니 입금 페이지와 기능을 구현하였습니다.
<br>

## 👨‍💻 작업 내용
- 지갑을 가져오는 것은 멤버를 지갑과 페치조인하여 가져와 사용하였습니다.
- 지갑에 들어오는 모든 입출금 기록을 남기기 위해서 WalletHistory 테이블을 아래와 같이 변경하였습니다.
![image](https://github.com/Team-Piglin/swapswap/assets/40788498/4f54b740-2747-467b-bdd1-3892f1f0fb6d)

<br>

## 🙇🏻‍♂️ 리뷰어에게
- 수수료를 지갑 기록에 넣으려고 했지만 그렇지 않았습니다. 지갑 기록에 넣기보단 거래 테이블에 수수료를 추가하는 것이 좋다고 생각하였기 때문입니다. 보통 거래내역에 수수료가 있지 입출금기록에는 총 금액만 담겨있기 떄문입니다.
<br>
