### PR TITLE
Refactor: Service Layer의 입금/출금 메서드 공통화

### DIFF
--- a/src/main/java/piglin/swapswap/domain/wallet/controller/WalletController.java
+++ b/src/main/java/piglin/swapswap/domain/wallet/controller/WalletController.java
@@ -12,6 +12,7 @@ import piglin.swapswap.domain.member.entity.Member;
 import piglin.swapswap.domain.wallet.dto.request.DepositSwapMoneyRequestDto;
 import piglin.swapswap.domain.wallet.dto.request.WithdrawSwapMoneyRequestDto;
 import piglin.swapswap.domain.wallet.service.WalletService;
+import piglin.swapswap.domain.wallethistory.constant.HistoryType;
 import piglin.swapswap.global.annotation.AuthMember;
 
 @Controller
@@ -31,12 +32,13 @@ public class WalletController {
     }
 
     @PostMapping("/deposit/normal")
-    public String depositSwapMoney(
+    public String normalDepositSwapMoney(
             @Valid @ModelAttribute("depositSwapMoneyRequestDto")
             DepositSwapMoneyRequestDto depositSwapMoneyRequestDto,
             @AuthMember Member member) {
 
-        walletService.normalDepositSwapMoney(depositSwapMoneyRequestDto.swapMoney(),
+        walletService.depositSwapMoney(depositSwapMoneyRequestDto.swapMoney(),
+                HistoryType.NORMAL_DEPOSIT,
                 member.getId());
 
         return "redirect:/members/swap-money";
@@ -56,7 +58,8 @@ public class WalletController {
             WithdrawSwapMoneyRequestDto withdrawSwapMoneyRequestDto,
             @AuthMember Member member) {
 
-        walletService.normalWithdrawSwapMoney(withdrawSwapMoneyRequestDto.swapMoney(),
+        walletService.withdrawSwapMoney(withdrawSwapMoneyRequestDto.swapMoney(),
+                HistoryType.NORMAL_WITHDRAW,
                 member.getId());
 
         return "redirect:/members/swap-money";

--- a/src/main/java/piglin/swapswap/domain/wallet/service/WalletService.java
+++ b/src/main/java/piglin/swapswap/domain/wallet/service/WalletService.java
@@ -1,12 +1,13 @@
 package piglin.swapswap.domain.wallet.service;
 
 import piglin.swapswap.domain.wallet.entity.Wallet;
+import piglin.swapswap.domain.wallethistory.constant.HistoryType;
 
 public interface WalletService {
 
     Wallet createWallet();
 
-    void normalDepositSwapMoney(Long depositSwapMoney, Long memberId);
+    void depositSwapMoney(Long depositSwapMoney, HistoryType historyType, Long memberId);
 
-    void normalWithdrawSwapMoney(Long withdrawSwapMoney, Long memberId);
+    void withdrawSwapMoney(Long withdrawSwapMoney, HistoryType historyType, Long memberId);
 }

--- a/src/main/java/piglin/swapswap/domain/wallet/service/WalletServiceImplV1.java
+++ b/src/main/java/piglin/swapswap/domain/wallet/service/WalletServiceImplV1.java
@@ -33,19 +33,19 @@ public class WalletServiceImplV1 implements WalletService {
 
     @Override
     @Transactional
-    public void normalDepositSwapMoney(Long depositSwapMoney, Long memberId) {
+    public void depositSwapMoney(Long depositSwapMoney, HistoryType historyType, Long memberId) {
 
         Member member = memberService.getMemberWithWallet(memberId);
 
         Wallet wallet = member.getWallet();
         wallet.depositSwapMoney(depositSwapMoney);
 
-        recordWalletHistory(depositSwapMoney, HistoryType.NORMAL_DEPOSIT);
+        recordWalletHistory(wallet, depositSwapMoney, historyType);
     }
 
     @Override
     @Transactional
-    public void normalWithdrawSwapMoney(Long withdrawSwapMoney, Long memberId) {
+    public void withdrawSwapMoney(Long withdrawSwapMoney, HistoryType historyType, Long memberId) {
 
         Member member = memberService.getMemberWithWallet(memberId);
 
@@ -55,7 +55,7 @@ public class WalletServiceImplV1 implements WalletService {
         }
         wallet.withdrawSwapMoney(withdrawSwapMoney);
 
-        recordWalletHistory(withdrawSwapMoney, HistoryType.NORMAL_WITHDRAW);
+        recordWalletHistory(wallet, withdrawSwapMoney, historyType);
     }
 
     private boolean impossibleWithdrawSwapMoney(Wallet wallet, Long withdrawSwapMoney) {
@@ -63,10 +63,11 @@ public class WalletServiceImplV1 implements WalletService {
         return wallet.getSwapMoney() < withdrawSwapMoney;
     }
 
-    private void recordWalletHistory(Long swapMoney, HistoryType historyType) {
+    private void recordWalletHistory(Wallet wallet, Long swapMoney, HistoryType historyType) {
 
-        WalletHistory walletHistory = WalletHistoryMapper.createWalletHistory(swapMoney,
+        WalletHistory walletHistory = WalletHistoryMapper.createWalletHistory(wallet, swapMoney,
                 historyType);
+
         walletHistoryService.recordWalletHistory(walletHistory);
     }
 }

--- a/src/main/java/piglin/swapswap/domain/wallethistory/entity/WalletHistory.java
+++ b/src/main/java/piglin/swapswap/domain/wallethistory/entity/WalletHistory.java
@@ -36,8 +36,8 @@ public class WalletHistory extends BaseTime {
     @Column(nullable = false)
     private Long swapMoney;
 
-    @ManyToOne
-    @JoinColumn(name = "wallet_id")
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "wallet_id", nullable = false)
     private Wallet wallet;
 
     @Column(nullable = false)

--- a/src/main/java/piglin/swapswap/domain/wallethistory/mapper/WalletHistoryMapper.java
+++ b/src/main/java/piglin/swapswap/domain/wallethistory/mapper/WalletHistoryMapper.java
@@ -1,13 +1,15 @@
 package piglin.swapswap.domain.wallethistory.mapper;
 
+import piglin.swapswap.domain.wallet.entity.Wallet;
 import piglin.swapswap.domain.wallethistory.constant.HistoryType;
 import piglin.swapswap.domain.wallethistory.entity.WalletHistory;
 
 public class WalletHistoryMapper {
 
-    public static WalletHistory createWalletHistory(Long swapMoney, HistoryType historyType) {
+    public static WalletHistory createWalletHistory(Wallet wallet, Long swapMoney, HistoryType historyType) {
 
         return WalletHistory.builder()
+                .wallet(wallet)
                 .historyType(historyType)
                 .swapMoney(swapMoney)
                 .isDeleted(false)


### PR DESCRIPTION
## 📝 개요
- 거래 완료 시, 공용으로 사용하기 위해서 메서드를 공통화
<br>

## 👨‍💻 작업 내용
- 거래 완료 시, 공용으로 사용하기 위해서 메서드를 공통화
- WalletHistory 엔티티 생성 시, 참조 값인 wallet을 누락해 추가
<br>

## 🙇🏻‍♂️ 리뷰어에게
- 거래 완료 시, 사용하게 될 walletservice에 문제가 없는지 확인해주세요
<br>
