### PR TITLE
fix: 게시글 없을 때 예외 클래스 NoMorePostListException 추가 및 전역 예외 핸들러 추가

### DIFF
--- a/src/main/java/piglin/swapswap/domain/post/service/PostServiceImplV1.java
+++ b/src/main/java/piglin/swapswap/domain/post/service/PostServiceImplV1.java
@@ -24,6 +24,7 @@ import piglin.swapswap.domain.post.mapper.PostMapper;
 import piglin.swapswap.domain.post.repository.PostRepository;
 import piglin.swapswap.global.exception.common.BusinessException;
 import piglin.swapswap.global.exception.common.ErrorCode;
+import piglin.swapswap.global.exception.post.NoMorePostListException;
 import piglin.swapswap.global.s3.S3ImageServiceImplV1;
 
 @Service
@@ -263,7 +264,7 @@ public class PostServiceImplV1 implements PostService {
     private void isEmptyPostList(List<PostGetListResponseDto> postList) {
 
         if (postList.isEmpty()) {
-            throw new RuntimeException("더 이상 불러올 게시글이 없습니다");
+            throw new NoMorePostListException();
         }
     }
 }

--- a/src/main/java/piglin/swapswap/global/exception/common/GlobalExceptionHandler.java
+++ b/src/main/java/piglin/swapswap/global/exception/common/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package piglin.swapswap.global.exception.common;
 import java.util.NoSuchElementException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataAccessException;
+import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageConversionException;
 import org.springframework.validation.BindException;
 import org.springframework.web.HttpMediaTypeNotSupportedException;
@@ -10,10 +11,12 @@ import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.servlet.view.RedirectView;
 import piglin.swapswap.global.exception.jwt.JwtInvalidException;
 import piglin.swapswap.global.exception.jwt.NoJwtException;
 import piglin.swapswap.global.exception.jwt.UnsupportedGrantTypeException;
+import piglin.swapswap.global.exception.post.NoMorePostListException;
 
 
 @Slf4j
@@ -95,6 +98,15 @@ public class GlobalExceptionHandler {
         log.error("HttpMediaTypeNotSupportedException", e);
 
         return new RedirectView("/error/errorpage");
+    }
+
+    @ResponseBody
+    @ExceptionHandler(NoMorePostListException.class)
+    protected ResponseEntity<?> handleNoMorePostListException(NoMorePostListException e) {
+
+        log.error("NoMorePostListException", e);
+
+        return ResponseEntity.status(400).build();
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/java/piglin/swapswap/global/exception/post/NoMorePostListException.java
+++ b/src/main/java/piglin/swapswap/global/exception/post/NoMorePostListException.java
@@ -1,0 +1,8 @@
+package piglin.swapswap.global.exception.post;
+
+public class NoMorePostListException extends RuntimeException {
+
+    public NoMorePostListException() {
+        super();
+    }
+}


### PR DESCRIPTION
## 📝 개요
- 현재 전역 에러페이지 잡는 기능을 추가하여 기존에 게시글 없을 때 alert 이 정상 작동을 안하는 문제가 발견 됐습니다.
<br>

## 👨‍💻 작업 내용
- NoMorePostList 예외를 추가했습니다.
- 전역 예외 핸들러에서 NoMorePostListException이 나오면 400에러를 반환하게끔 해서 정상적으로 alert이 띄워지게 했습니다.
<br>

## 🙇🏻‍♂️ 리뷰어에게
- 간단한 코드니 쓱 봐주세요~~
<br>
