### PR TITLE
fix: 안동 경상남도 -> 경상북도 수정...

### DIFF
--- a/src/main/resources/templates/common/fragments/nav.html
+++ b/src/main/resources/templates/common/fragments/nav.html
@@ -66,7 +66,6 @@
         <option value="HWASEONG">경기도 - 화성시</option>
 
         <option value="GIMHAE">경상남도 - 김해시</option>
-        <option value="ANDONG">경상남도 - 안동시</option>
         <option value="JINJU">경상남도 - 진주시</option>
         <option value="CHANGWON">경상남도 - 창원시</option>
         <option value="TONGYEONG">경상남도 - 통영시</option>
@@ -75,6 +74,7 @@
         <option value="GYEONGJU">경상북도 - 경주시</option>
         <option value="GUMI">경상북도 - 구미시</option>
         <option value="GIMCHEON">경상북도 - 김천시</option>
+        <option value="ANDONG">경상북도 - 안동시</option>
         <option value="YEONGJU">경상북도 - 영주시</option>
         <option value="YEONGCHEON">경상북도 - 영천시</option>
         <option value="POHANG">경상북도 - 포항시</option>


### PR DESCRIPTION
## 📝 개요
- 개발중 잘못 입력해서 경상남도로 올렸습니다.
<br>

## 👨‍💻 작업 내용
- 안동 경상남도 -> 경상북도 수정
<br>

## 🙇🏻‍♂️ 리뷰어에게
- 바로 머지하겠습니다.
<br>
