### PR TITLE
Fix: 모든 채팅방이 보이는 버그 해결

### DIFF
--- a/src/main/java/piglin/swapswap/domain/chatroom/repository/ChatRoomQueryRepositoryImpl.java
+++ b/src/main/java/piglin/swapswap/domain/chatroom/repository/ChatRoomQueryRepositoryImpl.java
@@ -36,7 +36,7 @@ public class ChatRoomQueryRepositoryImpl implements ChatRoomQueryRepository{
                 .from(chatRoomMember)
                 .join(chatRoom).on(chatRoomMember.chatRoom.id.eq(chatRoom.id))
                 .join(member).on(chatRoomMember.member.id.eq(member.id))
-                .where(memberIdNotEq(memberId))
+                .where(chatRoomIdIn(memberId),memberIdNotEq(memberId))
                 .fetch();
     }
 
@@ -62,5 +62,14 @@ public class ChatRoomQueryRepositoryImpl implements ChatRoomQueryRepository{
 
         return chatRoomMember.member.id.eq(memberId);
     }
+
+    private BooleanExpression chatRoomIdIn(Long memberId) {
+        return chatRoom.id.in(JPAExpressions
+                .select(chatRoomMember.chatRoom.id)
+                .from(chatRoomMember)
+                .where(memberIdEq(memberId)));
+    }
+
+
 
 }


### PR DESCRIPTION
## 📝 개요
- 모든 채팅방이 보이는 버그 해결
<br>

## 👨‍💻 작업 내용
- 채팅방 목록을 불러오는 쿼리 수정

**수정 전 코드**
```java
queryFactory
                .select(Projections.constructor(ChatRoomResponseDto.class,
                        chatRoom.id,
                        member.nickname,
                        chatRoom.lastMessage,
                        chatRoom.lastMessageTime))
                .from(chatRoomMember)
                .join(chatRoom).on(chatRoomMember.chatRoom.id.eq(chatRoom.id))
                .join(member).on(chatRoomMember.member.id.eq(member.id))
                .where(chatRoomIdIn(memberId),memberIdNotEq(memberId))
                .fetch();
```

**수정한 코드**
```java
queryFactory
                .select(Projections.constructor(ChatRoomResponseDto.class,
                        chatRoom.id,
                        member.nickname,
                        chatRoom.lastMessage,
                        chatRoom.lastMessageTime))
                .from(chatRoomMember)
                .join(chatRoom).on(chatRoomMember.chatRoom.id.eq(chatRoom.id))
                .join(member).on(chatRoomMember.member.id.eq(member.id))
                .where(memberIdNotEq(memberId))
                .fetch();
```
<br>
