### PR TITLE
feat: 작성자가 아닐 시 수정, 업, 삭제 버튼 안뜨게 수정

### DIFF
--- a/src/main/java/piglin/swapswap/domain/post/controller/PostController.java
+++ b/src/main/java/piglin/swapswap/domain/post/controller/PostController.java
@@ -68,6 +68,15 @@ public class PostController {
         model.addAttribute("postGetResponseDto", responseDto);
         model.addAttribute("postId", postId);
 
+        String seeMemberNickname;
+        if(member == null) {
+            seeMemberNickname = "";
+        } else {
+            seeMemberNickname = member.getNickname();
+        }
+
+        model.addAttribute("isWriter", responseDto.author().equals(seeMemberNickname));
+
         return "post/post";
     }
 

--- a/src/main/resources/templates/post/post.html
+++ b/src/main/resources/templates/post/post.html
@@ -22,7 +22,7 @@
             <input class="author-id" type="hidden" th:value="${postGetResponseDto.memberId}">
             <span class="author-name" th:text="${postGetResponseDto.author}"></span>
           </div>
-          <div class="post-update-button"><a th:href="@{/posts/{postId}/write(postId=${postId})}" sec:authorize="isAuthenticated()">수정하기</a>
+          <div th:if="${isWriter}" class="post-update-button"><a th:href="@{/posts/{postId}/write(postId=${postId})}" sec:authorize="isAuthenticated()">수정하기</a>
           </div>
           <div class="chat-request-button"
                th:data-member-id="${postGetResponseDto.memberId}"
@@ -33,9 +33,11 @@
             <a th:href="@{/deals/request(secondMemberId=${postGetResponseDto.memberId},memberName=${postGetResponseDto.author})}" sec:authorize="isAuthenticated()">요청하기</a>
           </div>
           <div class="post-up-button"
+               th:if="${isWriter}"
                th:data-post-id="${postId}"
                th:onclick="upPost(this.getAttribute('data-post-id'))"><a sec:authorize="isAuthenticated()">업하기</a></div>
           <div class="post-delete-button"
+               th:if="${isWriter}"
                th:data-post-id="${postId}"
                th:onclick="deletePost(this.getAttribute('data-post-id'))">
             <a sec:authorize="isAuthenticated()">삭제하기</a>


### PR DESCRIPTION
## 📝 개요
- 게시글을 볼 때 작성자가 아닌데도 수정, 채팅, 삭제 버튼이 떠서 내 게시글인지, 남의 게시글인지 헷갈렸습니다.
<br>

## 👨‍💻 작업 내용
- 작성자가 아닐 시 수정, 업, 삭제 버튼이 뜨지 않게 수정했습니다.
<br>

## 🙇🏻‍♂️ 리뷰어에게
- 쓱 봐주세요!
- 자신의 게시글
![스크린샷 2024-01-21 오후 5 17 17](https://github.com/Team-Piglin/swapswap/assets/123870616/84a322e7-2019-4ea0-bd4f-25fc89b414c7)
- 타 유저의 게시글
![스크린샷 2024-01-21 오후 5 21 28](https://github.com/Team-Piglin/swapswap/assets/123870616/0289b777-85e8-4206-af76-2bd3fe5e4797)

<br>
