### PR TITLE
feat: 거래 상태에 따른 포스트에 거래상태 표시 기능 구현

### DIFF
--- a/src/main/java/piglin/swapswap/domain/deal/service/DealServiceImplV1.java
+++ b/src/main/java/piglin/swapswap/domain/deal/service/DealServiceImplV1.java
@@ -16,7 +16,6 @@ import piglin.swapswap.domain.deal.mapper.DealMapper;
 import piglin.swapswap.domain.deal.repository.DealRepository;
 import piglin.swapswap.domain.member.entity.Member;
 import piglin.swapswap.domain.member.repository.MemberRepository;
-import piglin.swapswap.domain.post.entity.Post;
 import piglin.swapswap.domain.post.service.PostService;
 import piglin.swapswap.global.exception.common.BusinessException;
 import piglin.swapswap.global.exception.common.ErrorCode;

--- a/src/main/java/piglin/swapswap/domain/deal/service/DealServiceImplV1.java
+++ b/src/main/java/piglin/swapswap/domain/deal/service/DealServiceImplV1.java
@@ -15,7 +15,6 @@ import piglin.swapswap.domain.deal.mapper.DealMapper;
 import piglin.swapswap.domain.deal.repository.DealRepository;
 import piglin.swapswap.domain.member.entity.Member;
 import piglin.swapswap.domain.member.repository.MemberRepository;
-import piglin.swapswap.domain.post.entity.Post;
 import piglin.swapswap.domain.post.service.PostService;
 import piglin.swapswap.global.exception.common.BusinessException;
 import piglin.swapswap.global.exception.common.ErrorCode;

--- a/src/main/java/piglin/swapswap/domain/deal/service/DealServiceImplV1.java
+++ b/src/main/java/piglin/swapswap/domain/deal/service/DealServiceImplV1.java
@@ -124,6 +124,7 @@ public class DealServiceImplV1 implements DealService {
             for(int i = 0; i<deal.getSecondPostIdList().size(); i++){
                 postIdList.add(deal.getSecondPostIdList().get(i));
             }
+            
             postService.updatePostStatusByPostIdList(postIdList, DealStatus.DEALING);
         }
     }

--- a/src/main/java/piglin/swapswap/domain/deal/service/DealServiceImplV1.java
+++ b/src/main/java/piglin/swapswap/domain/deal/service/DealServiceImplV1.java
@@ -15,6 +15,8 @@ import piglin.swapswap.domain.deal.mapper.DealMapper;
 import piglin.swapswap.domain.deal.repository.DealRepository;
 import piglin.swapswap.domain.member.entity.Member;
 import piglin.swapswap.domain.member.repository.MemberRepository;
+import piglin.swapswap.domain.post.entity.Post;
+import piglin.swapswap.domain.post.service.PostService;
 import piglin.swapswap.global.exception.common.BusinessException;
 import piglin.swapswap.global.exception.common.ErrorCode;
 
@@ -25,6 +27,7 @@ public class DealServiceImplV1 implements DealService {
 
     private final DealRepository dealRepository;
     private final MemberRepository memberRepository;
+    private final PostService postService;
 
     @Override
     public Long createDeal(Member member, DealCreateRequestDto requestDto) {
@@ -113,6 +116,7 @@ public class DealServiceImplV1 implements DealService {
 
         if(deal.getFirstAllow() && deal.getSecondAllow()) {
             deal.updateDealStatus(DealStatus.DEALING);
+            postService.getPostIdList(deal);
         }
     }
 

--- a/src/main/java/piglin/swapswap/domain/deal/service/DealServiceImplV1.java
+++ b/src/main/java/piglin/swapswap/domain/deal/service/DealServiceImplV1.java
@@ -1,5 +1,6 @@
 package piglin.swapswap.domain.deal.service;
 
+import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -15,6 +16,7 @@ import piglin.swapswap.domain.deal.mapper.DealMapper;
 import piglin.swapswap.domain.deal.repository.DealRepository;
 import piglin.swapswap.domain.member.entity.Member;
 import piglin.swapswap.domain.member.repository.MemberRepository;
+import piglin.swapswap.domain.post.entity.Post;
 import piglin.swapswap.domain.post.service.PostService;
 import piglin.swapswap.global.exception.common.BusinessException;
 import piglin.swapswap.global.exception.common.ErrorCode;
@@ -115,7 +117,15 @@ public class DealServiceImplV1 implements DealService {
 
         if(deal.getFirstAllow() && deal.getSecondAllow()) {
             deal.updateDealStatus(DealStatus.DEALING);
-            postService.getPostIdList(deal);
+
+            List<Long> postIdList = new ArrayList<>();
+            for(int i = 0; i<deal.getFirstPostIdList().size(); i++){
+                postIdList.add(deal.getFirstPostIdList().get(i));
+            }
+            for(int i = 0; i<deal.getSecondPostIdList().size(); i++){
+                postIdList.add(deal.getSecondPostIdList().get(i));
+            }
+            postService.updatePostStatusByPostIdList(postIdList, DealStatus.DEALING);
         }
     }
 
@@ -139,7 +149,16 @@ public class DealServiceImplV1 implements DealService {
 
         if(deal.getFirstTake() && deal.getSecondTake()) {
             deal.updateDealStatus(DealStatus.COMPLETED);
-            postService.getPostIdList(deal);
+
+            List<Long> postIdList = new ArrayList<>();
+            for(int i = 0; i<deal.getFirstPostIdList().size(); i++){
+                postIdList.add(deal.getFirstPostIdList().get(i));
+            }
+            for(int i = 0; i<deal.getSecondPostIdList().size(); i++){
+                postIdList.add(deal.getSecondPostIdList().get(i));
+            }
+
+            postService.updatePostStatusByPostIdList(postIdList, DealStatus.COMPLETED);
         }
 
         if(!deal.getFirstTake() || !deal.getSecondTake()) {

--- a/src/main/java/piglin/swapswap/domain/deal/service/DealServiceImplV1.java
+++ b/src/main/java/piglin/swapswap/domain/deal/service/DealServiceImplV1.java
@@ -140,6 +140,7 @@ public class DealServiceImplV1 implements DealService {
 
         if(deal.getFirstTake() && deal.getSecondTake()) {
             deal.updateDealStatus(DealStatus.COMPLETED);
+            postService.getPostIdList(deal);
         }
 
         if(!deal.getFirstTake() || !deal.getSecondTake()) {

--- a/src/main/java/piglin/swapswap/domain/post/entity/Post.java
+++ b/src/main/java/piglin/swapswap/domain/post/entity/Post.java
@@ -93,4 +93,9 @@ public class Post extends BaseTime {
         this.upCnt++;
         this.modifiedUpTime = LocalDateTime.now();
     }
+
+    public void updatePostDealStatus(DealStatus dealStatus) {
+
+        this.dealStatus = dealStatus;
+    }
 }

--- a/src/main/java/piglin/swapswap/domain/post/service/PostService.java
+++ b/src/main/java/piglin/swapswap/domain/post/service/PostService.java
@@ -3,6 +3,7 @@ package piglin.swapswap.domain.post.service;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
+import piglin.swapswap.domain.deal.constant.DealStatus;
 import piglin.swapswap.domain.deal.entity.Deal;
 import piglin.swapswap.domain.member.entity.Member;
 import piglin.swapswap.domain.post.dto.request.PostCreateRequestDto;
@@ -102,5 +103,5 @@ public interface PostService {
 
     List<PostGetListResponseDto> getMyPostListMore(Member member, LocalDateTime cursorTime);
 
-    List<Post> getPostIdList(Deal deal);
+    void updatePostStatusByPostIdList(List<Long> postIdList, DealStatus dealStatus);
 }

--- a/src/main/java/piglin/swapswap/domain/post/service/PostService.java
+++ b/src/main/java/piglin/swapswap/domain/post/service/PostService.java
@@ -3,12 +3,14 @@ package piglin.swapswap.domain.post.service;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
+import piglin.swapswap.domain.deal.entity.Deal;
 import piglin.swapswap.domain.member.entity.Member;
 import piglin.swapswap.domain.post.dto.request.PostCreateRequestDto;
 import piglin.swapswap.domain.post.dto.request.PostUpdateRequestDto;
 import piglin.swapswap.domain.post.dto.response.PostGetListResponseDto;
 import piglin.swapswap.domain.post.dto.response.PostGetResponseDto;
 import piglin.swapswap.domain.post.dto.response.PostSimpleResponseDto;
+import piglin.swapswap.domain.post.entity.Post;
 
 public interface PostService {
 
@@ -99,4 +101,6 @@ public interface PostService {
     List<PostGetListResponseDto> getMyPostList(Member member, LocalDateTime cursorTime);
 
     List<PostGetListResponseDto> getMyPostListMore(Member member, LocalDateTime cursorTime);
+
+    List<Post> getPostIdList(Deal deal);
 }

--- a/src/main/java/piglin/swapswap/domain/post/service/PostService.java
+++ b/src/main/java/piglin/swapswap/domain/post/service/PostService.java
@@ -4,14 +4,12 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import piglin.swapswap.domain.deal.constant.DealStatus;
-import piglin.swapswap.domain.deal.entity.Deal;
 import piglin.swapswap.domain.member.entity.Member;
 import piglin.swapswap.domain.post.dto.request.PostCreateRequestDto;
 import piglin.swapswap.domain.post.dto.request.PostUpdateRequestDto;
 import piglin.swapswap.domain.post.dto.response.PostGetListResponseDto;
 import piglin.swapswap.domain.post.dto.response.PostGetResponseDto;
 import piglin.swapswap.domain.post.dto.response.PostSimpleResponseDto;
-import piglin.swapswap.domain.post.entity.Post;
 
 public interface PostService {
 

--- a/src/main/java/piglin/swapswap/domain/post/service/PostServiceImplV1.java
+++ b/src/main/java/piglin/swapswap/domain/post/service/PostServiceImplV1.java
@@ -1,7 +1,5 @@
 package piglin.swapswap.domain.post.service;
 
-import static piglin.swapswap.domain.post.entity.QPost.post;
-
 import jakarta.transaction.Transactional;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -13,7 +11,6 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import piglin.swapswap.domain.deal.constant.DealStatus;
-import piglin.swapswap.domain.deal.entity.Deal;
 import piglin.swapswap.domain.favorite.service.FavoriteService;
 import piglin.swapswap.domain.member.entity.Member;
 import piglin.swapswap.domain.post.constant.Category;
@@ -21,9 +18,9 @@ import piglin.swapswap.domain.post.constant.City;
 import piglin.swapswap.domain.post.constant.PostConstant;
 import piglin.swapswap.domain.post.dto.request.PostCreateRequestDto;
 import piglin.swapswap.domain.post.dto.request.PostUpdateRequestDto;
-import piglin.swapswap.domain.post.dto.response.PostSimpleResponseDto;
 import piglin.swapswap.domain.post.dto.response.PostGetListResponseDto;
 import piglin.swapswap.domain.post.dto.response.PostGetResponseDto;
+import piglin.swapswap.domain.post.dto.response.PostSimpleResponseDto;
 import piglin.swapswap.domain.post.entity.Post;
 import piglin.swapswap.domain.post.event.DeleteImageUrlMapEvent;
 import piglin.swapswap.domain.post.mapper.PostMapper;

--- a/src/main/java/piglin/swapswap/domain/post/service/PostServiceImplV1.java
+++ b/src/main/java/piglin/swapswap/domain/post/service/PostServiceImplV1.java
@@ -238,24 +238,12 @@ public class PostServiceImplV1 implements PostService {
     }
 
     @Override
-    public List<Post> getPostIdList(Deal deal) {
+    public void updatePostStatusByPostIdList(List<Long> postIdList, DealStatus dealStatus) {
 
-        List<Post> postIdList = new ArrayList<>();
-
-        for (int i = 0; i<deal.getFirstPostIdList().size(); i++){
-
-            Post post = findPost(deal.getFirstPostIdList().get(i));
-            postIdList.add(post);
-            post.updatePostDealStatus(deal.getDealStatus());
+        for (Long postId : postIdList) {
+            Post post = findPost(postId);
+            post.updatePostDealStatus(dealStatus);
         }
-        for (int i = 0; i<deal.getSecondPostIdList().size(); i++){
-
-            Post secondPost = findPost(deal.getSecondPostIdList().get(i));
-            postIdList.add(secondPost);
-            secondPost.updatePostDealStatus(deal.getDealStatus());
-        }
-
-        return postIdList;
     }
 
     @Override

--- a/src/main/java/piglin/swapswap/domain/post/service/PostServiceImplV1.java
+++ b/src/main/java/piglin/swapswap/domain/post/service/PostServiceImplV1.java
@@ -1,5 +1,7 @@
 package piglin.swapswap.domain.post.service;
 
+import static piglin.swapswap.domain.post.entity.QPost.post;
+
 import jakarta.transaction.Transactional;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -10,6 +12,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
+import piglin.swapswap.domain.deal.constant.DealStatus;
+import piglin.swapswap.domain.deal.entity.Deal;
 import piglin.swapswap.domain.favorite.service.FavoriteService;
 import piglin.swapswap.domain.member.entity.Member;
 import piglin.swapswap.domain.post.constant.Category;
@@ -221,14 +225,37 @@ public class PostServiceImplV1 implements PostService {
             Map<Integer, Long> postIdList) {
 
         List<PostSimpleResponseDto> responseDtoList = new ArrayList<>();
-
         for(int i = 0; i < postIdList.size(); i++) {
+
             Long postId = postIdList.get(i);
+
             Post post = findPost(postId);
+
             responseDtoList.add(PostMapper.getPostSimpleInfoListByPost(post));
         }
 
         return responseDtoList;
+    }
+
+    @Override
+    public List<Post> getPostIdList(Deal deal) {
+
+        List<Post> postIdList = new ArrayList<>();
+
+        for (int i = 0; i<deal.getFirstPostIdList().size(); i++){
+
+            Post post = findPost(deal.getFirstPostIdList().get(i));
+            postIdList.add(post);
+            post.updatePostDealStatus(deal.getDealStatus());
+        }
+        for (int i = 0; i<deal.getSecondPostIdList().size(); i++){
+
+            Post secondPost = findPost(deal.getSecondPostIdList().get(i));
+            postIdList.add(secondPost);
+            secondPost.updatePostDealStatus(deal.getDealStatus());
+        }
+
+        return postIdList;
     }
 
     @Override

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -53,4 +53,4 @@ cloud:
 kakao:
   client:
     id: ENC(DmCqicA7Pa7EFxu5XTVtBxYl3K6fHeM1nSl090T2k+aJXj/JxcAnC1++VMpiz2ZU)
-  redirect-uri: http://localhost:8080/login/kakao/callback
+  redirect-uri: http://swapswap.shop//login/kakao/callback

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -53,4 +53,4 @@ cloud:
 kakao:
   client:
     id: ENC(DmCqicA7Pa7EFxu5XTVtBxYl3K6fHeM1nSl090T2k+aJXj/JxcAnC1++VMpiz2ZU)
-  redirect-uri: http://swapswap.shop//login/kakao/callback
+  redirect-uri: http://localhost:8080/login/kakao/callback

--- a/src/main/resources/templates/post/post.html
+++ b/src/main/resources/templates/post/post.html
@@ -34,7 +34,7 @@
             <a>채팅하기</a>
           </div>
           <div class="post-request-button">
-            <a th:href="@{/deals/request(secondMemberId=${postGetResponseDto.memberId},memberName=${postGetResponseDto.author})}" sec:authorize="isAuthenticated()">요청하기</a>
+            <a th:href="@{/deals/request(secondMemberId=${postGetResponseDto.memberId},memberName=${postGetResponseDto.author})}" sec:authorize="isAuthenticated()" th:if="${postGetResponseDto.dealStatus == postGetResponseDto.dealStatus.REQUESTED}">요청하기</a>
           </div>
           <div class="post-up-button"
                th:if="${isWriter}"


### PR DESCRIPTION
## 📝 개요
- 거래 상태에 따른 포스트에 거래상태 표시 기능 구현
- #158 에 관한 내용 브랜치 명만 수정하여 다시 올렸습니다.
<br>

## 👨‍💻 작업 내용
- 거래 요청 후 유저 모두 수락 시 거래 진행으로 표시, post의 거래 상태도 업데이트
- 거래 인수도 모두 인수 시 거래 완료로 표시 및 요청 상태가 아닌 deal에 대해서는 요청할 수 없게 요청하기 버튼 삭제
<br>

## 🙇🏻‍♂️ 리뷰어에게
-  내용대로 동작은 정상으로 돌아갑니다. 하지만 postServiceImpl 부분에
 return 쪽에 문제가 있을 것 같습니다. 그부분을 중점으로 봐주시면 감사하겠습니다.  
<br>
