### PR TITLE
Fix: 유저 닉네임 + 숫자 4개로 구성되도록 수정 및 프론트에서 중복된 닉네임 검사

### DIFF
--- a/src/main/java/piglin/swapswap/domain/member/constant/AnimalAdjective.java
+++ b/src/main/java/piglin/swapswap/domain/member/constant/AnimalAdjective.java
@@ -1,0 +1,24 @@
+package piglin.swapswap.domain.member.constant;
+
+import lombok.Getter;
+
+@Getter
+public enum AnimalAdjective {
+    ACTIVE("활발한"),
+    ELEGANT("우아한"),
+    LOVABLE("사랑스러운"),
+    AGILE("민첩한"),
+    CUTE("귀여운"),
+    STRONG("튼튼한"),
+    COLORFUL("화려한"),
+    CHARMING("정겨운"),
+    INTELLIGENT("영리한"),
+    BRAVE("용감한");
+
+    private final String adjective;
+
+    AnimalAdjective(String adjective) {
+        this.adjective = adjective;
+    }
+}
+

--- a/src/main/java/piglin/swapswap/domain/member/constant/AnimalName.java
+++ b/src/main/java/piglin/swapswap/domain/member/constant/AnimalName.java
@@ -1,0 +1,23 @@
+package piglin.swapswap.domain.member.constant;
+
+import lombok.Getter;
+
+@Getter
+public enum AnimalName {
+    CAT("고양이"),
+    DOG("개"),
+    ELEPHANT("코끼리"),
+    PANDA("판다"),
+    TIGER("호랑이"),
+    ZEBRA("얼룩말"),
+    DOLPHIN("돌고래"),
+    LION("사자"),
+    OWL("올빼미"),
+    PENGUIN("펭귄");
+
+    private final String name;
+
+    AnimalName(String name) {
+        this.name = name;
+    }
+}

--- a/src/main/java/piglin/swapswap/domain/member/contorller/MemberController.java
+++ b/src/main/java/piglin/swapswap/domain/member/contorller/MemberController.java
@@ -144,4 +144,11 @@ public class MemberController {
 
         return "post/postListFragment";
     }
+
+    @ResponseBody
+    @GetMapping("/members/checkNickname")
+    public ResponseEntity<?> checkNickname(@RequestParam String nickname) {
+        boolean nicknameExists = memberService.checkNicknameExists(nickname);
+        return ResponseEntity.ok(nicknameExists);
+    }
 }

--- a/src/main/java/piglin/swapswap/domain/member/dto/MemberNicknameDto.java
+++ b/src/main/java/piglin/swapswap/domain/member/dto/MemberNicknameDto.java
@@ -4,7 +4,7 @@ import jakarta.validation.constraints.Pattern;
 
 public record MemberNicknameDto(
 
-        @Pattern(regexp = "^[a-zA-Z0-9가-힣]{2,10}$", message = "한글, 알파벳 대,소문자, 숫자로 구성해주세요")
+        @Pattern(regexp = "^[a-zA-Z0-9가-힣]{2,15}$", message = "한글, 알파벳 대,소문자, 숫자로 구성해주세요")
         String nickname) {
 
 }

--- a/src/main/java/piglin/swapswap/domain/member/entity/Member.java
+++ b/src/main/java/piglin/swapswap/domain/member/entity/Member.java
@@ -33,7 +33,7 @@ public class Member extends BaseTime {
     @Column(nullable = false, length = 40)
     private String email;
 
-    @Column(nullable = false, length = 20)
+    @Column(nullable = false, length = 15)
     private String nickname;
 
     @Enumerated(value = EnumType.STRING)

--- a/src/main/java/piglin/swapswap/domain/member/repository/MemberRepository.java
+++ b/src/main/java/piglin/swapswap/domain/member/repository/MemberRepository.java
@@ -21,4 +21,5 @@ public interface MemberRepository extends JpaRepository<Member, Long>, MemberQue
 
     boolean existsByIdAndIsDeletedIsFalse(Long memberId);
 
+    boolean existsByNickname(String nickname);
 }

--- a/src/main/java/piglin/swapswap/domain/member/service/KakaoServiceImpl.java
+++ b/src/main/java/piglin/swapswap/domain/member/service/KakaoServiceImpl.java
@@ -17,6 +17,8 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
+import piglin.swapswap.domain.member.constant.AnimalAdjective;
+import piglin.swapswap.domain.member.constant.AnimalName;
 import piglin.swapswap.domain.member.dto.SocialUserInfo;
 import piglin.swapswap.domain.member.entity.Member;
 import piglin.swapswap.domain.member.mapper.MemberMapper;
@@ -116,22 +118,27 @@ public class KakaoServiceImpl implements SocialService {
             throw new RuntimeException(e);
         }
         Long id = jsonNode.get("id").asLong();
-        String originalNickname = jsonNode.get("properties")
-                .get("nickname").asText();
         String email = jsonNode.get("kakao_account")
                 .get("email").asText();
 
-        String uniqueNumbers = UUID.randomUUID().toString().substring(0, 4);
-        String nickname = originalNickname + uniqueNumbers;
+        AnimalAdjective randomAdjective = getRandomEnum(AnimalAdjective.class);
+        AnimalName randomAnimalName = getRandomEnum(AnimalName.class);
+
+        String nickname = randomAdjective.getAdjective() + randomAnimalName.getName() + UUID.randomUUID().toString().substring(0, 4);
 
         while (memberRepository.existsByNickname(nickname)) {
-            String uniqueNumber = UUID.randomUUID().toString().substring(0, 4);
-            nickname = originalNickname + uniqueNumber;
+            nickname = randomAdjective.getAdjective() + randomAnimalName.getName() + UUID.randomUUID().toString().substring(0, 4);
         }
 
         log.info("카카오 사용자 정보: " + id + ", " + nickname + ", " + email);
 
         return SocialUserInfo.createSocialUserInfo(id, nickname, email);
+    }
+
+    private <T extends Enum<?>> T getRandomEnum(Class<T> enumClass) {
+        T[] enumConstants = enumClass.getEnumConstants();
+        int randomIndex = (int) (Math.random() * enumConstants.length);
+        return enumConstants[randomIndex];
     }
 
     public Member registerUserIfNeeded(SocialUserInfo kakaoUserInfo) {

--- a/src/main/java/piglin/swapswap/domain/member/service/KakaoServiceImpl.java
+++ b/src/main/java/piglin/swapswap/domain/member/service/KakaoServiceImpl.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.transaction.Transactional;
 import java.net.URI;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.beans.factory.annotation.Value;
@@ -115,10 +116,18 @@ public class KakaoServiceImpl implements SocialService {
             throw new RuntimeException(e);
         }
         Long id = jsonNode.get("id").asLong();
-        String nickname = jsonNode.get("properties")
+        String originalNickname = jsonNode.get("properties")
                 .get("nickname").asText();
         String email = jsonNode.get("kakao_account")
                 .get("email").asText();
+
+        String uniqueNumbers = UUID.randomUUID().toString().substring(0, 4);
+        String nickname = originalNickname + uniqueNumbers;
+
+        while (memberRepository.existsByNickname(nickname)) {
+            String uniqueNumber = UUID.randomUUID().toString().substring(0, 4);
+            nickname = originalNickname + uniqueNumber;
+        }
 
         log.info("카카오 사용자 정보: " + id + ", " + nickname + ", " + email);
 

--- a/src/main/java/piglin/swapswap/domain/member/service/MemberService.java
+++ b/src/main/java/piglin/swapswap/domain/member/service/MemberService.java
@@ -15,4 +15,5 @@ public interface MemberService {
 
     Member getMember(Long memberId);
 
+    boolean checkNicknameExists(String nickname);
 }

--- a/src/main/java/piglin/swapswap/domain/member/service/MemberServiceImplV1.java
+++ b/src/main/java/piglin/swapswap/domain/member/service/MemberServiceImplV1.java
@@ -33,9 +33,10 @@ public class MemberServiceImplV1 implements MemberService {
     @Transactional
     public void deleteMember(Member loginMember) {
 
-        Member member = memberRepository.findByIdAndIsDeletedIsFalse(loginMember.getId()).orElseThrow(
-                () -> new BusinessException(ErrorCode.NOT_FOUND_USER_EXCEPTION)
-        );
+        Member member = memberRepository.findByIdAndIsDeletedIsFalse(loginMember.getId())
+                .orElseThrow(
+                        () -> new BusinessException(ErrorCode.NOT_FOUND_USER_EXCEPTION)
+                );
 
         member.deleteMember();
     }
@@ -60,5 +61,10 @@ public class MemberServiceImplV1 implements MemberService {
 
         return memberRepository.findById(memberId).orElseThrow(
                 () -> new BusinessException(ErrorCode.NOT_FOUND_USER_EXCEPTION));
+    }
+
+    @Override
+    public boolean checkNicknameExists(String nickname) {
+        return memberRepository.existsByNickname(nickname);
     }
 }

--- a/src/main/resources/templates/member/editProfile.html
+++ b/src/main/resources/templates/member/editProfile.html
@@ -22,7 +22,7 @@
         if (newNickname === originalNickname) {
           event.preventDefault();
           alert('변경하려는 닉네임이 현재 닉네임과 같습니다');
-        } else if (newNickname.length >= 2 && newNickname.length <= 10 && /^[a-zA-Z0-9가-힣]+$/.test(
+        } else if (newNickname.length >= 2 && newNickname.length <= 15 && /^[a-zA-Z0-9가-힣]+$/.test(
             newNickname)) {
           var xhr = new XMLHttpRequest();
           xhr.open('GET', '/members/checkNickname?nickname=' + newNickname, true);
@@ -65,7 +65,7 @@
           xhr.send();
         } else {
           event.preventDefault();
-          alert('닉네임은 특수 문자를 제외한 2자 이상 10자 이내로 설정해주세요');
+          alert('닉네임은 특수 문자를 제외한 2자 이상 15자 이내로 설정해주세요');
         }
       });
     });

--- a/src/main/resources/templates/member/editProfile.html
+++ b/src/main/resources/templates/member/editProfile.html
@@ -17,34 +17,52 @@
       var originalNickname = nicknameSpan.innerText.trim();
 
       document.querySelector('#nicknameLink').addEventListener('click', function (event) {
-
         var newNickname = nicknameSpan.innerText.trim();
+
         if (newNickname === originalNickname) {
           event.preventDefault();
           alert('변경하려는 닉네임이 현재 닉네임과 같습니다');
-        } else if (newNickname.length >= 2 && newNickname.length <= 10 && /^[a-zA-Z0-9가-힣]+$/.test(newNickname)) {
+        } else if (newNickname.length >= 2 && newNickname.length <= 10 && /^[a-zA-Z0-9가-힣]+$/.test(
+            newNickname)) {
           var xhr = new XMLHttpRequest();
-          xhr.open('PATCH', '/members/nickname', true);
-          xhr.setRequestHeader('Content-Type', 'application/json');
-
-          alert('닉네임이 정상적으로 변경되었습니다');
-          originalNickname = newNickname;
+          xhr.open('GET', '/members/checkNickname?nickname=' + newNickname, true);
           xhr.onload = function () {
             if (xhr.status === 200) {
-              console.log("success")
-              window.location.href = '/myPage';
+              var isDuplicate = JSON.parse(xhr.responseText);
+              if (isDuplicate) {
+                alert('이미 존재하는 닉네임입니다.');
+              } else {
+                var xhrPatch = new XMLHttpRequest();
+                xhrPatch.open('PATCH', '/members/nickname', true);
+                xhrPatch.setRequestHeader('Content-Type', 'application/json');
 
+                alert('닉네임이 정상적으로 변경되었습니다');
+                originalNickname = newNickname;
+                xhrPatch.onload = function () {
+                  if (xhrPatch.status === 200) {
+                    console.log("success")
+                    window.location.href = '/myPage';
+                  } else {
+                    console.error('닉네임 업데이트 오류:', xhrPatch.statusText);
+                  }
+                };
+
+                xhrPatch.onerror = function () {
+                  console.error('요청 실패');
+                  console.error(xhrPatch);
+                };
+
+                xhrPatch.send(JSON.stringify({nickname: newNickname}));
+              }
             } else {
-              console.error('닉네임 업데이트 오류:', xhr.statusText);
+              console.error('닉네임 중복 확인 오류:', xhr.statusText);
             }
           };
-
           xhr.onerror = function () {
             console.error('요청 실패');
             console.error(xhr);
           };
-
-          xhr.send(JSON.stringify({nickname: newNickname}));
+          xhr.send();
         } else {
           event.preventDefault();
           alert('닉네임은 특수 문자를 제외한 2자 이상 10자 이내로 설정해주세요');


### PR DESCRIPTION
## 📝 개요
- [#155]
- [#161]
- 유저 닉네임 + 숫자 4개로 구성되도록 수정 및 프론트에서 중복된 닉네임 검사
<br>

## 👨‍💻 작업 내용
- 유저가 카카오로 로그인을 하여 db에 저장될 때 기존에는 닉네임에 실명이 들어가서 중복이 될 수 밖에 없는 상황이고 닉네임을 수정할 때는 중복이 되지 않는 상황이였는데 애초에 db에 저장될 때 실명 + 숫자 4개로 구성되게 하여 중복을 방지하였습니다

![UUID](https://github.com/Team-Piglin/swapswap/assets/120416027/832c76e7-b654-4441-873f-30a073601a1c)
------
- 닉네임을 수정할 때 중복검사를 백엔드에서는 해줬지만 프론트에서 해주지 않아 중복됨에도 불구하고 정상적으로 변경되었다는 알림만 뜨고 실제로는 변경이 되지 않았는데 수정하였습니다.
![중복 프론트](https://github.com/Team-Piglin/swapswap/assets/120416027/d55334d6-d7e1-4147-a00f-1d1bd06e0287)
------
<br>

## 🙇🏻‍♂️ 리뷰어에게
- 비교적 간단한 코드라 스-윽 봐주시고 고칠 부분있으면 말씀해주세요
<br>
