### PR TITLE
Feat:  스왑 페이와 거래 연동 기능 구현

### DIFF
--- a/src/main/java/piglin/swapswap/domain/daelwallet/entity/DealWallet.java
+++ b/src/main/java/piglin/swapswap/domain/daelwallet/entity/DealWallet.java
@@ -1,0 +1,46 @@
+package piglin.swapswap.domain.daelwallet.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import piglin.swapswap.domain.common.BaseTime;
+import piglin.swapswap.domain.deal.entity.Deal;
+
+@Entity
+@Builder
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DealWallet extends BaseTime {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column
+    private Long firstSwapMoney;
+
+    @Column
+    private Long secondSwapMoney;
+
+    @OneToOne(optional = false)
+    @JoinColumn(name = "deal_id", nullable = false)
+    private Deal deal;
+
+    public void updateFirstSwapMoney(Long swapMoney) {
+        this.firstSwapMoney = swapMoney;
+    }
+
+    public void updateSecondSwapMoney(Long swapMoney) {
+        this.secondSwapMoney = swapMoney;
+    }
+}

--- a/src/main/java/piglin/swapswap/domain/daelwallet/mapper/DealWalletMapper.java
+++ b/src/main/java/piglin/swapswap/domain/daelwallet/mapper/DealWalletMapper.java
@@ -1,0 +1,17 @@
+package piglin.swapswap.domain.daelwallet.mapper;
+
+import piglin.swapswap.domain.daelwallet.entity.DealWallet;
+import piglin.swapswap.domain.deal.entity.Deal;
+
+public class DealWalletMapper {
+
+    public static DealWallet setDealWallet(Deal deal, Long firstSwapMoney, Long secondSwapMoney) {
+
+        return DealWallet.builder()
+                .deal(deal)
+                .firstSwapMoney(firstSwapMoney)
+                .secondSwapMoney(secondSwapMoney)
+                .build();
+    }
+
+}

--- a/src/main/java/piglin/swapswap/domain/daelwallet/repository/DealWalletRepository.java
+++ b/src/main/java/piglin/swapswap/domain/daelwallet/repository/DealWalletRepository.java
@@ -3,7 +3,6 @@ package piglin.swapswap.domain.daelwallet.repository;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import piglin.swapswap.domain.daelwallet.entity.DealWallet;
-import piglin.swapswap.domain.wallet.entity.Wallet;
 
 public interface DealWalletRepository extends JpaRepository<DealWallet, Long> {
 

--- a/src/main/java/piglin/swapswap/domain/daelwallet/repository/DealWalletRepository.java
+++ b/src/main/java/piglin/swapswap/domain/daelwallet/repository/DealWalletRepository.java
@@ -1,0 +1,13 @@
+package piglin.swapswap.domain.daelwallet.repository;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import piglin.swapswap.domain.daelwallet.entity.DealWallet;
+import piglin.swapswap.domain.wallet.entity.Wallet;
+
+public interface DealWalletRepository extends JpaRepository<DealWallet, Long> {
+
+    boolean existsByDealId(Long dealId);
+
+    Optional<DealWallet> findByDealId(Long dealId);
+}

--- a/src/main/java/piglin/swapswap/domain/daelwallet/service/DealWalletService.java
+++ b/src/main/java/piglin/swapswap/domain/daelwallet/service/DealWalletService.java
@@ -16,5 +16,6 @@ public interface DealWalletService {
      void withdrawMemberSwapMoneyAtComplete(Deal deal);
 
      void withdrawMemberSwapMoneyAtDealUpdate(Deal deal);
+
      Boolean existsDealWallet(Long dealId);
 }

--- a/src/main/java/piglin/swapswap/domain/daelwallet/service/DealWalletService.java
+++ b/src/main/java/piglin/swapswap/domain/daelwallet/service/DealWalletService.java
@@ -15,5 +15,6 @@ public interface DealWalletService {
 
      void withdrawMemberSwapMoneyAtComplete(Deal deal);
 
+     void withdrawMemberSwapMoneyAtDealUpdate(Deal deal);
      Boolean existsDealWallet(Long dealId);
 }

--- a/src/main/java/piglin/swapswap/domain/daelwallet/service/DealWalletService.java
+++ b/src/main/java/piglin/swapswap/domain/daelwallet/service/DealWalletService.java
@@ -1,0 +1,19 @@
+package piglin.swapswap.domain.daelwallet.service;
+
+import piglin.swapswap.domain.deal.entity.Deal;
+import piglin.swapswap.domain.member.entity.Member;
+
+public interface DealWalletService {
+
+
+
+     void createDealWallet(Deal deal, Member member, Long firstSwapMoney);
+
+     void updateDealWallet(Deal deal, Member member, Long firstSwapMoney);
+
+     void withdrawMemberSwapMoneyAtUpdate(Deal deal, Member member);
+
+     void withdrawMemberSwapMoneyAtComplete(Deal deal);
+
+     Boolean existsDealWallet(Long dealId);
+}

--- a/src/main/java/piglin/swapswap/domain/daelwallet/service/DealWalletService.java
+++ b/src/main/java/piglin/swapswap/domain/daelwallet/service/DealWalletService.java
@@ -7,9 +7,9 @@ public interface DealWalletService {
 
 
 
-     void createDealWallet(Deal deal, Member member, Long firstSwapMoney);
+     void createDealWallet(Deal deal, Member member, Long swapMoney);
 
-     void updateDealWallet(Deal deal, Member member, Long firstSwapMoney);
+     void updateDealWallet(Deal deal, Member member, Long swapMoney);
 
      void withdrawMemberSwapMoneyAtUpdate(Deal deal, Member member);
 

--- a/src/main/java/piglin/swapswap/domain/daelwallet/service/DealWalletServiceImplV1.java
+++ b/src/main/java/piglin/swapswap/domain/daelwallet/service/DealWalletServiceImplV1.java
@@ -61,16 +61,22 @@ public class DealWalletServiceImplV1 implements DealWalletService {
         Long swapMoney = 0L;
 
         if (deal.getFirstUserId().equals(member.getId())) {
-            swapMoney = dealWallet.getFirstSwapMoney();
+            if (!(dealWallet.getFirstSwapMoney() == null)) {
+                swapMoney = dealWallet.getFirstSwapMoney();
+            }
             dealWallet.updateFirstSwapMoney(null);
         }
 
         if (deal.getSecondUserId().equals(member.getId())) {
-            swapMoney = dealWallet.getSecondSwapMoney();
+            if (!(dealWallet.getSecondSwapMoney() == null)) {
+                swapMoney = dealWallet.getSecondSwapMoney();
+            }
             dealWallet.updateSecondSwapMoney(null);
         }
 
-        walletService.depositSwapMoney(swapMoney, HistoryType.DEAL_DEPOSIT, member.getId());
+        if(!(swapMoney == 0L)) {
+            walletService.depositSwapMoney(swapMoney, HistoryType.DEAL_DEPOSIT, member.getId());
+        }
     }
 
     @Override
@@ -103,6 +109,12 @@ public class DealWalletServiceImplV1 implements DealWalletService {
         }
 
         dealWalletRepository.delete(dealWallet);
+    }
+
+    @Override
+    public Boolean existsDealWallet(Long dealId) {
+
+        return dealWalletRepository.existsByDealId(dealId);
     }
 
     private DealWallet getDealWallet(Deal deal) {

--- a/src/main/java/piglin/swapswap/domain/daelwallet/service/DealWalletServiceImplV1.java
+++ b/src/main/java/piglin/swapswap/domain/daelwallet/service/DealWalletServiceImplV1.java
@@ -1,0 +1,96 @@
+package piglin.swapswap.domain.daelwallet.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import piglin.swapswap.domain.daelwallet.entity.DealWallet;
+import piglin.swapswap.domain.daelwallet.mapper.DealWalletMapper;
+import piglin.swapswap.domain.daelwallet.repository.DealWalletRepository;
+import piglin.swapswap.domain.deal.entity.Deal;
+import piglin.swapswap.domain.member.entity.Member;
+import piglin.swapswap.domain.wallet.service.WalletService;
+import piglin.swapswap.domain.wallethistory.constant.HistoryType;
+
+@Service
+@RequiredArgsConstructor
+public class DealWalletServiceImplV1 implements DealWalletService {
+
+    private final DealWalletRepository dealWalletRepository;
+    private final WalletService walletService;
+
+    @Override
+    @Transactional
+    public void createDealWallet(Deal deal, Member member, Long swapMoney) {
+
+        DealWallet dealWallet = DealWalletMapper.setDealWallet(deal, null, null);
+
+        if (deal.getFirstUserId().equals(member.getId())) {
+            dealWallet.updateFirstSwapMoney(swapMoney);
+        }
+
+        if (deal.getSecondUserId().equals(member.getId())) {
+            dealWallet.updateSecondSwapMoney(swapMoney);
+        }
+
+        walletService.withdrawSwapMoney(swapMoney, HistoryType.DEAL_WITHDRAW, member.getId());
+
+        dealWalletRepository.save(dealWallet);
+    }
+
+    @Override
+    public void updateDealWallet(Deal deal, Member member, Long swapMoney) {
+
+        DealWallet dealWallet = dealWalletRepository.findByDealId(deal.getId()).orElseThrow(
+                () -> new RuntimeException("")
+        );
+
+        if(deal.getFirstUserId().equals(member.getId())) {
+            dealWallet.updateFirstSwapMoney(swapMoney);
+        }
+
+        if(deal.getSecondUserId().equals(member.getId())) {
+            dealWallet.updateSecondSwapMoney(swapMoney);
+        }
+
+        walletService.withdrawSwapMoney(swapMoney, HistoryType.DEAL_WITHDRAW, member.getId());
+    }
+
+    @Override
+    public void withdrawMemberSwapMoneyAtUpdate(Deal deal, Member member) {
+
+        DealWallet dealWallet = dealWalletRepository.findByDealId(deal.getId()).orElseThrow(
+                () -> new RuntimeException("")
+        );
+
+        Long swapMoney = 0L;
+
+        if(deal.getFirstUserId().equals(member.getId())) {
+            swapMoney = dealWallet.getFirstSwapMoney();
+            dealWallet.updateFirstSwapMoney(null);
+        }
+
+        if(deal.getSecondUserId().equals(member.getId())) {
+            swapMoney = dealWallet.getSecondSwapMoney();
+            dealWallet.updateSecondSwapMoney(null);
+        }
+
+        walletService.depositSwapMoney(swapMoney, HistoryType.DEAL_DEPOSIT, member.getId());
+    }
+
+    @Override
+    public void withdrawMemberSwapMoneyAtComplete(Deal deal) {
+
+        DealWallet dealWallet  = dealWalletRepository.findByDealId(deal.getId()).orElseThrow(
+                () -> new RuntimeException("")
+        );
+
+        walletService.depositSwapMoney(dealWallet.getFirstSwapMoney(),HistoryType.DEAL_DEPOSIT , deal.getSecondUserId());
+        walletService.depositSwapMoney(dealWallet.getSecondSwapMoney(),HistoryType.DEAL_DEPOSIT , deal.getFirstUserId());
+    }
+
+    @Override
+    public Boolean existsDealWallet(Long dealId) {
+
+        return dealWalletRepository.existsByDealId(dealId);
+    }
+}

--- a/src/main/java/piglin/swapswap/domain/daelwallet/service/DealWalletServiceImplV1.java
+++ b/src/main/java/piglin/swapswap/domain/daelwallet/service/DealWalletServiceImplV1.java
@@ -61,14 +61,14 @@ public class DealWalletServiceImplV1 implements DealWalletService {
         Long swapMoney = 0L;
 
         if (deal.getFirstUserId().equals(member.getId())) {
-            if (!(dealWallet.getFirstSwapMoney() == null)) {
+            if (dealWallet.getFirstSwapMoney() != null) {
                 swapMoney = dealWallet.getFirstSwapMoney();
             }
             dealWallet.updateFirstSwapMoney(null);
         }
 
         if (deal.getSecondUserId().equals(member.getId())) {
-            if (!(dealWallet.getSecondSwapMoney() == null)) {
+            if (dealWallet.getSecondSwapMoney() != null) {
                 swapMoney = dealWallet.getSecondSwapMoney();
             }
             dealWallet.updateSecondSwapMoney(null);
@@ -84,11 +84,11 @@ public class DealWalletServiceImplV1 implements DealWalletService {
 
         DealWallet dealWallet = findDealWalletByDeal(deal);
 
-        if (!(dealWallet.getFirstSwapMoney() == null)) {
+        if (dealWallet.getFirstSwapMoney() != null) {
             walletService.depositSwapMoney(dealWallet.getFirstSwapMoney(), HistoryType.DEAL_DEPOSIT,
                     deal.getSecondUserId());
         }
-        if (!(dealWallet.getSecondSwapMoney() == null)) {
+        if (dealWallet.getSecondSwapMoney() != null) {
             walletService.depositSwapMoney(dealWallet.getSecondSwapMoney(),
                     HistoryType.DEAL_DEPOSIT, deal.getFirstUserId());
         }
@@ -99,11 +99,11 @@ public class DealWalletServiceImplV1 implements DealWalletService {
 
         DealWallet dealWallet = getDealWallet(deal);
 
-        if (!(dealWallet.getFirstSwapMoney() == null)) {
+        if (dealWallet.getFirstSwapMoney() != null) {
             walletService.depositSwapMoney(dealWallet.getFirstSwapMoney(), HistoryType.DEAL_DEPOSIT,
                     deal.getFirstUserId());
         }
-        if (!(dealWallet.getSecondSwapMoney() == null)) {
+        if (dealWallet.getSecondSwapMoney() != null) {
             walletService.depositSwapMoney(dealWallet.getSecondSwapMoney(),
                     HistoryType.DEAL_DEPOSIT, deal.getSecondUserId());
         }

--- a/src/main/java/piglin/swapswap/domain/daelwallet/service/DealWalletServiceImplV1.java
+++ b/src/main/java/piglin/swapswap/domain/daelwallet/service/DealWalletServiceImplV1.java
@@ -40,8 +40,7 @@ public class DealWalletServiceImplV1 implements DealWalletService {
     @Override
     public void updateDealWallet(Deal deal, Member member, Long swapMoney) {
 
-        DealWallet dealWallet = dealWalletRepository.findByDealId(deal.getId())
-                .orElseThrow(() -> new RuntimeException(""));
+        DealWallet dealWallet = findDealWalletByDeal(deal);
 
         if (deal.getFirstUserId().equals(member.getId())) {
             dealWallet.updateFirstSwapMoney(swapMoney);
@@ -57,8 +56,7 @@ public class DealWalletServiceImplV1 implements DealWalletService {
     @Override
     public void withdrawMemberSwapMoneyAtUpdate(Deal deal, Member member) {
 
-        DealWallet dealWallet = dealWalletRepository.findByDealId(deal.getId())
-                .orElseThrow(() -> new RuntimeException(""));
+        DealWallet dealWallet = findDealWalletByDeal(deal);
 
         Long swapMoney = 0L;
 
@@ -78,8 +76,7 @@ public class DealWalletServiceImplV1 implements DealWalletService {
     @Override
     public void withdrawMemberSwapMoneyAtComplete(Deal deal) {
 
-        DealWallet dealWallet = dealWalletRepository.findByDealId(deal.getId())
-                .orElseThrow(() -> new RuntimeException(""));
+        DealWallet dealWallet = findDealWalletByDeal(deal);
 
         if (!(dealWallet.getFirstSwapMoney() == null)) {
             walletService.depositSwapMoney(dealWallet.getFirstSwapMoney(), HistoryType.DEAL_DEPOSIT,
@@ -94,8 +91,7 @@ public class DealWalletServiceImplV1 implements DealWalletService {
     @Override
     public void withdrawMemberSwapMoneyAtDealUpdate(Deal deal) {
 
-        DealWallet dealWallet = dealWalletRepository.findByDealId(deal.getId())
-                .orElseThrow(() -> new RuntimeException(""));
+        DealWallet dealWallet = getDealWallet(deal);
 
         if (!(dealWallet.getFirstSwapMoney() == null)) {
             walletService.depositSwapMoney(dealWallet.getFirstSwapMoney(), HistoryType.DEAL_DEPOSIT,
@@ -109,9 +105,13 @@ public class DealWalletServiceImplV1 implements DealWalletService {
         dealWalletRepository.delete(dealWallet);
     }
 
-    @Override
-    public Boolean existsDealWallet(Long dealId) {
+    private DealWallet getDealWallet(Deal deal) {
+        return findDealWalletByDeal(deal);
+    }
 
-        return dealWalletRepository.existsByDealId(dealId);
+    private DealWallet findDealWalletByDeal(Deal deal) {
+
+        return dealWalletRepository.findByDealId(deal.getId())
+                .orElseThrow(() -> new RuntimeException(""));
     }
 }

--- a/src/main/java/piglin/swapswap/domain/daelwallet/service/DealWalletServiceImplV1.java
+++ b/src/main/java/piglin/swapswap/domain/daelwallet/service/DealWalletServiceImplV1.java
@@ -40,15 +40,14 @@ public class DealWalletServiceImplV1 implements DealWalletService {
     @Override
     public void updateDealWallet(Deal deal, Member member, Long swapMoney) {
 
-        DealWallet dealWallet = dealWalletRepository.findByDealId(deal.getId()).orElseThrow(
-                () -> new RuntimeException("")
-        );
+        DealWallet dealWallet = dealWalletRepository.findByDealId(deal.getId())
+                .orElseThrow(() -> new RuntimeException(""));
 
-        if(deal.getFirstUserId().equals(member.getId())) {
+        if (deal.getFirstUserId().equals(member.getId())) {
             dealWallet.updateFirstSwapMoney(swapMoney);
         }
 
-        if(deal.getSecondUserId().equals(member.getId())) {
+        if (deal.getSecondUserId().equals(member.getId())) {
             dealWallet.updateSecondSwapMoney(swapMoney);
         }
 
@@ -58,18 +57,17 @@ public class DealWalletServiceImplV1 implements DealWalletService {
     @Override
     public void withdrawMemberSwapMoneyAtUpdate(Deal deal, Member member) {
 
-        DealWallet dealWallet = dealWalletRepository.findByDealId(deal.getId()).orElseThrow(
-                () -> new RuntimeException("")
-        );
+        DealWallet dealWallet = dealWalletRepository.findByDealId(deal.getId())
+                .orElseThrow(() -> new RuntimeException(""));
 
         Long swapMoney = 0L;
 
-        if(deal.getFirstUserId().equals(member.getId())) {
+        if (deal.getFirstUserId().equals(member.getId())) {
             swapMoney = dealWallet.getFirstSwapMoney();
             dealWallet.updateFirstSwapMoney(null);
         }
 
-        if(deal.getSecondUserId().equals(member.getId())) {
+        if (deal.getSecondUserId().equals(member.getId())) {
             swapMoney = dealWallet.getSecondSwapMoney();
             dealWallet.updateSecondSwapMoney(null);
         }
@@ -80,12 +78,35 @@ public class DealWalletServiceImplV1 implements DealWalletService {
     @Override
     public void withdrawMemberSwapMoneyAtComplete(Deal deal) {
 
-        DealWallet dealWallet  = dealWalletRepository.findByDealId(deal.getId()).orElseThrow(
-                () -> new RuntimeException("")
-        );
+        DealWallet dealWallet = dealWalletRepository.findByDealId(deal.getId())
+                .orElseThrow(() -> new RuntimeException(""));
 
-        walletService.depositSwapMoney(dealWallet.getFirstSwapMoney(),HistoryType.DEAL_DEPOSIT , deal.getSecondUserId());
-        walletService.depositSwapMoney(dealWallet.getSecondSwapMoney(),HistoryType.DEAL_DEPOSIT , deal.getFirstUserId());
+        if (!(dealWallet.getFirstSwapMoney() == null)) {
+            walletService.depositSwapMoney(dealWallet.getFirstSwapMoney(), HistoryType.DEAL_DEPOSIT,
+                    deal.getSecondUserId());
+        }
+        if (!(dealWallet.getSecondSwapMoney() == null)) {
+            walletService.depositSwapMoney(dealWallet.getSecondSwapMoney(),
+                    HistoryType.DEAL_DEPOSIT, deal.getFirstUserId());
+        }
+    }
+
+    @Override
+    public void withdrawMemberSwapMoneyAtDealUpdate(Deal deal) {
+
+        DealWallet dealWallet = dealWalletRepository.findByDealId(deal.getId())
+                .orElseThrow(() -> new RuntimeException(""));
+
+        if (!(dealWallet.getFirstSwapMoney() == null)) {
+            walletService.depositSwapMoney(dealWallet.getFirstSwapMoney(), HistoryType.DEAL_DEPOSIT,
+                    deal.getFirstUserId());
+        }
+        if (!(dealWallet.getSecondSwapMoney() == null)) {
+            walletService.depositSwapMoney(dealWallet.getSecondSwapMoney(),
+                    HistoryType.DEAL_DEPOSIT, deal.getSecondUserId());
+        }
+
+        dealWalletRepository.delete(dealWallet);
     }
 
     @Override

--- a/src/main/java/piglin/swapswap/domain/deal/controller/DealController.java
+++ b/src/main/java/piglin/swapswap/domain/deal/controller/DealController.java
@@ -56,7 +56,7 @@ public class DealController {
         model.addAttribute("memberId", member.getId());
 
         model.addAttribute("dealCreateRequestDto", new DealCreateRequestDto(
-                0, 0, null, null, null));
+                0L, 0L, null, null, null));
 
         return "deal/dealCreateForm";
     }
@@ -115,7 +115,7 @@ public class DealController {
         model.addAttribute("memberId", memberId);
         model.addAttribute("dealId",dealId);
         model.addAttribute("dealUpdateRequestDto", new DealUpdateRequestDto(
-                0, null));
+                0L, null));
 
         return "deal/dealUpdateForm";
     }
@@ -134,6 +134,15 @@ public class DealController {
     public ResponseEntity<?> takeDeal(@PathVariable Long dealId, @AuthMember Member member) {
 
         dealService.takeDeal(dealId, member);
+
+        return ResponseEntity.ok().build();
+    }
+
+    @ResponseBody
+    @PatchMapping("/{dealId}/use")
+    public ResponseEntity<?> updateDealSwapMoneyIsUsing(@PathVariable Long dealId, @AuthMember Member member) {
+
+        dealService.updateDealSwapMoneyIsUsing(dealId, member);
 
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/piglin/swapswap/domain/deal/controller/DealController.java
+++ b/src/main/java/piglin/swapswap/domain/deal/controller/DealController.java
@@ -56,7 +56,7 @@ public class DealController {
         model.addAttribute("memberId", member.getId());
 
         model.addAttribute("dealCreateRequestDto", new DealCreateRequestDto(
-                0L, 0L, null, null, null));
+                null, null, null, null, null));
 
         return "deal/dealCreateForm";
     }
@@ -115,7 +115,7 @@ public class DealController {
         model.addAttribute("memberId", memberId);
         model.addAttribute("dealId",dealId);
         model.addAttribute("dealUpdateRequestDto", new DealUpdateRequestDto(
-                0L, null));
+                null, null));
 
         return "deal/dealUpdateForm";
     }

--- a/src/main/java/piglin/swapswap/domain/deal/controller/DealController.java
+++ b/src/main/java/piglin/swapswap/domain/deal/controller/DealController.java
@@ -139,7 +139,7 @@ public class DealController {
     }
 
     @ResponseBody
-    @PatchMapping("/{dealId}/use")
+    @PatchMapping("/{dealId}/swapmoney")
     public ResponseEntity<?> updateDealSwapMoneyIsUsing(@PathVariable Long dealId, @AuthMember Member member) {
 
         dealService.updateDealSwapMoneyIsUsing(dealId, member);

--- a/src/main/java/piglin/swapswap/domain/deal/dto/request/DealCreateRequestDto.java
+++ b/src/main/java/piglin/swapswap/domain/deal/dto/request/DealCreateRequestDto.java
@@ -5,9 +5,9 @@ import jakarta.validation.constraints.PositiveOrZero;
 import java.util.List;
 public record DealCreateRequestDto (
         @PositiveOrZero
-        int firstExtraFee,
+        Long firstExtraFee,
         @PositiveOrZero
-        int secondExtraFee,
+        Long secondExtraFee,
         List<Long> firstPostIdList,
         List<Long> secondPostIdList,
         @NotNull

--- a/src/main/java/piglin/swapswap/domain/deal/dto/request/DealUpdateRequestDto.java
+++ b/src/main/java/piglin/swapswap/domain/deal/dto/request/DealUpdateRequestDto.java
@@ -5,7 +5,7 @@ import java.util.List;
 
 public record DealUpdateRequestDto (
         @PositiveOrZero
-        int extraFee,
+        Long extraFee,
         List<Long> postIdList
 ) {
 }

--- a/src/main/java/piglin/swapswap/domain/deal/dto/response/DealDetailResponseDto.java
+++ b/src/main/java/piglin/swapswap/domain/deal/dto/response/DealDetailResponseDto.java
@@ -20,9 +20,9 @@ public record DealDetailResponseDto(
 
          Map<Integer, Long> secondPostIdList,
 
-         int firstExtraFee,
+         Long firstExtraFee,
 
-         int secondExtraFee,
+         Long secondExtraFee,
 
          Boolean firstAllow,
 
@@ -30,7 +30,11 @@ public record DealDetailResponseDto(
 
          Boolean firstTake,
 
-         Boolean secondTake
+         Boolean secondTake,
+
+         Boolean isFirstSwapMoneyUsed,
+
+         Boolean isSecondSwapMoneyUsed
 ) {
 
 }

--- a/src/main/java/piglin/swapswap/domain/deal/entity/Deal.java
+++ b/src/main/java/piglin/swapswap/domain/deal/entity/Deal.java
@@ -48,10 +48,10 @@ public class Deal extends BaseTime {
     @Column(columnDefinition = "json")
     private Map<Integer, Long> secondPostIdList;
 
-    @Column(nullable = false)
+    @Column
     private Long firstExtraFee;
 
-    @Column(nullable = false)
+    @Column
     private Long secondExtraFee;
 
     @Column(nullable = false)

--- a/src/main/java/piglin/swapswap/domain/deal/entity/Deal.java
+++ b/src/main/java/piglin/swapswap/domain/deal/entity/Deal.java
@@ -5,9 +5,12 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
 import java.time.LocalDateTime;
 import java.util.Map;
 import lombok.AccessLevel;
@@ -17,6 +20,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.Type;
 import piglin.swapswap.domain.common.BaseTime;
+import piglin.swapswap.domain.daelwallet.entity.DealWallet;
 import piglin.swapswap.domain.deal.constant.DealStatus;
 
 @Entity
@@ -49,10 +53,10 @@ public class Deal extends BaseTime {
     private Map<Integer, Long> secondPostIdList;
 
     @Column(nullable = false)
-    private int firstExtraFee;
+    private Long firstExtraFee;
 
     @Column(nullable = false)
-    private int secondExtraFee;
+    private Long secondExtraFee;
 
     @Column(nullable = false)
     private Boolean firstAllow;
@@ -66,10 +70,16 @@ public class Deal extends BaseTime {
     @Column(nullable = false)
     private Boolean secondTake;
 
+    @Column(nullable = false)
+    private Boolean isFirstSwapMoneyUsed;
+
+    @Column(nullable = false)
+    private Boolean isSecondSwapMoneyUsed;
+
     @Column
     private LocalDateTime completedDealTime;
 
-    public void updateDealFirst(int firstExtraFee, Map<Integer, Long> firstPostIdMap) {
+    public void updateDealFirst(Long firstExtraFee, Map<Integer, Long> firstPostIdMap) {
 
         this.firstExtraFee = firstExtraFee;
         this.firstPostIdList = firstPostIdMap;
@@ -77,7 +87,7 @@ public class Deal extends BaseTime {
         this.secondAllow = false;
     }
 
-    public void updateDealSecond(int secondExtraFee, Map<Integer, Long> secondPostIdMap) {
+    public void updateDealSecond(Long secondExtraFee, Map<Integer, Long> secondPostIdMap) {
 
         this.secondExtraFee = secondExtraFee;
         this.secondPostIdList = secondPostIdMap;
@@ -103,6 +113,16 @@ public class Deal extends BaseTime {
     public void updateDealSecondMemberTake() {
 
         secondTake = true;
+    }
+
+    public void updateDealFirstMemberSwapMoneyUsing() {
+
+        isFirstSwapMoneyUsed = !isFirstSwapMoneyUsed;
+    }
+
+    public void updateDealSecondMemberSwapMoneyUsing() {
+
+        isSecondSwapMoneyUsed = !isSecondSwapMoneyUsed;
     }
 
     public void updateDealStatus(DealStatus dealStatus) {

--- a/src/main/java/piglin/swapswap/domain/deal/entity/Deal.java
+++ b/src/main/java/piglin/swapswap/domain/deal/entity/Deal.java
@@ -5,12 +5,9 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.OneToOne;
 import java.time.LocalDateTime;
 import java.util.Map;
 import lombok.AccessLevel;
@@ -20,7 +17,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.Type;
 import piglin.swapswap.domain.common.BaseTime;
-import piglin.swapswap.domain.daelwallet.entity.DealWallet;
 import piglin.swapswap.domain.deal.constant.DealStatus;
 
 @Entity

--- a/src/main/java/piglin/swapswap/domain/deal/mapper/DealMapper.java
+++ b/src/main/java/piglin/swapswap/domain/deal/mapper/DealMapper.java
@@ -20,7 +20,7 @@ public class DealMapper {
                 .dealStatus(DealStatus.REQUESTED)
                 .firstUserId(firstUserId)
                 .secondUserId(requestDto.secondMemberId())
-                .firstAllow(true)
+                .firstAllow(false)
                 .secondAllow(false)
                 .firstTake(false)
                 .secondTake(false)

--- a/src/main/java/piglin/swapswap/domain/deal/mapper/DealMapper.java
+++ b/src/main/java/piglin/swapswap/domain/deal/mapper/DealMapper.java
@@ -24,6 +24,8 @@ public class DealMapper {
                 .secondAllow(false)
                 .firstTake(false)
                 .secondTake(false)
+                .isFirstSwapMoneyUsed(false)
+                .isSecondSwapMoneyUsed(false)
                 .firstPostIdList(firstPostIdListMap)
                 .secondPostIdList(secondPostIdListMap)
                 .firstExtraFee(requestDto.firstExtraFee())

--- a/src/main/java/piglin/swapswap/domain/deal/repository/DealQueryRepositoryImpl.java
+++ b/src/main/java/piglin/swapswap/domain/deal/repository/DealQueryRepositoryImpl.java
@@ -72,7 +72,9 @@ public class DealQueryRepositoryImpl implements DealQueryRepository {
                                 deal.firstAllow,
                                 deal.secondAllow,
                                 deal.firstTake,
-                                deal.secondTake))
+                                deal.secondTake,
+                                deal.isFirstSwapMoneyUsed,
+                                deal.isSecondSwapMoneyUsed))
                 .from(deal)
                 .where(deal.id.eq(dealId))
                 .fetchOne();

--- a/src/main/java/piglin/swapswap/domain/deal/service/DealService.java
+++ b/src/main/java/piglin/swapswap/domain/deal/service/DealService.java
@@ -26,5 +26,7 @@ public interface DealService {
 
     void takeDeal(Long deal, Member member);
 
+    void updateDealSwapMoneyIsUsing(Long dealId, Member member);
+
     List<DealHistoryResponseDto> getDealHistoryList(Long memberId);
 }

--- a/src/main/java/piglin/swapswap/domain/deal/service/DealServiceImplV1.java
+++ b/src/main/java/piglin/swapswap/domain/deal/service/DealServiceImplV1.java
@@ -18,7 +18,6 @@ import piglin.swapswap.domain.deal.repository.DealRepository;
 import piglin.swapswap.domain.member.entity.Member;
 import piglin.swapswap.domain.member.repository.MemberRepository;
 import piglin.swapswap.domain.post.service.PostService;
-import piglin.swapswap.domain.wallet.service.WalletService;
 import piglin.swapswap.global.exception.common.BusinessException;
 import piglin.swapswap.global.exception.common.ErrorCode;
 
@@ -121,18 +120,18 @@ public class DealServiceImplV1 implements DealService {
             Long firstExtraFee = deal.getFirstExtraFee();
 
             if(deal.getIsFirstSwapMoneyUsed()) {
-                if (dealWalletService.existsDealWallet(dealId) ) { // Deal Wallet 이 있다면
+                if (dealWalletService.existsDealWallet(dealId) ) {
 
-                    if (deal.getFirstAllow()) { // 스왑머니를 사용하고, Allow 가 True로 바뀌었으면
+                    if (deal.getFirstAllow()) {
                         dealWalletService.updateDealWallet(deal, member, firstExtraFee);
                     }
 
-                    if (!deal.getFirstAllow()) { // 스왑머니를 사용하고, Allow가 False 로 바뀌었으면
+                    if (!deal.getFirstAllow()) {
                         dealWalletService.withdrawMemberSwapMoneyAtUpdate(deal, member);
                     }
                 }
 
-                if (!dealWalletService.existsDealWallet(dealId)) { // Deal Wallet 이 없다면
+                if (!dealWalletService.existsDealWallet(dealId)) {
 
                     if (deal.getFirstAllow()) {
                         dealWalletService.createDealWallet(deal, member, firstExtraFee);
@@ -148,18 +147,18 @@ public class DealServiceImplV1 implements DealService {
             Long secondExtraFee = deal.getSecondExtraFee();
 
             if(deal.getIsSecondSwapMoneyUsed()) {
-                if (dealWalletService.existsDealWallet(dealId) ) { // Deal Wallet 이 있다면
+                if (dealWalletService.existsDealWallet(dealId) ) {
 
-                    if (deal.getSecondAllow()) { // 스왑머니를 사용하고, Allow 가 True로 바뀌었으면
+                    if (deal.getSecondAllow()) {
                         dealWalletService.updateDealWallet(deal, member, secondExtraFee);
                     }
 
-                    if (!deal.getSecondAllow()) { // 스왑머니를 사용하고, Allow가 False 로 바뀌었으면
+                    if (!deal.getSecondAllow()) {
                         dealWalletService.withdrawMemberSwapMoneyAtUpdate(deal, member);
                     }
                 }
 
-                if (!dealWalletService.existsDealWallet(dealId)) { // Deal Wallet 이 없다면
+                if (!dealWalletService.existsDealWallet(dealId)) {
 
                     if (deal.getSecondAllow()) {
                         dealWalletService.createDealWallet(deal, member, secondExtraFee);
@@ -278,9 +277,4 @@ public class DealServiceImplV1 implements DealService {
             throw new BusinessException(ErrorCode.NOT_FOUND_POST_EXCEPTION);
         }
     }
-
-//    private Boolean firstMemberSwapMoneyIsUsing(Deal deal){
-//
-//        return  deal.getFirstAllow() && deal.getFirstSwapMoneyIsUsing();
-//    }
 }

--- a/src/main/java/piglin/swapswap/domain/deal/service/DealServiceImplV1.java
+++ b/src/main/java/piglin/swapswap/domain/deal/service/DealServiceImplV1.java
@@ -117,7 +117,11 @@ public class DealServiceImplV1 implements DealService {
 
             deal.updateDealFirstMemberAllow();
 
-            Long firstExtraFee = deal.getFirstExtraFee();
+            Long firstExtraFee = null;
+
+            if(deal.getFirstExtraFee() != null) {
+                firstExtraFee = deal.getFirstExtraFee();
+            }
 
             if(deal.getIsFirstSwapMoneyUsed()) {
                 if (dealWalletService.existsDealWallet(dealId) ) {
@@ -134,7 +138,9 @@ public class DealServiceImplV1 implements DealService {
                 if (!dealWalletService.existsDealWallet(dealId)) {
 
                     if (deal.getFirstAllow()) {
-                        dealWalletService.createDealWallet(deal, member, firstExtraFee);
+                        if (deal.getFirstExtraFee() != null) {
+                            dealWalletService.createDealWallet(deal, member, firstExtraFee);
+                        }
                     }
                 }
             }
@@ -144,7 +150,11 @@ public class DealServiceImplV1 implements DealService {
 
             deal.updateDealSecondMemberAllow();
 
-            Long secondExtraFee = deal.getSecondExtraFee();
+            Long secondExtraFee = null;
+
+            if(deal.getSecondExtraFee() != null) {
+                secondExtraFee = deal.getSecondExtraFee();
+            }
 
             if(deal.getIsSecondSwapMoneyUsed()) {
                 if (dealWalletService.existsDealWallet(dealId) ) {
@@ -161,7 +171,9 @@ public class DealServiceImplV1 implements DealService {
                 if (!dealWalletService.existsDealWallet(dealId)) {
 
                     if (deal.getSecondAllow()) {
-                        dealWalletService.createDealWallet(deal, member, secondExtraFee);
+                        if (deal.getSecondExtraFee() != null) {
+                            dealWalletService.createDealWallet(deal, member, secondExtraFee);
+                        }
                     }
                 }
             }

--- a/src/main/java/piglin/swapswap/domain/deal/service/DealServiceImplV1.java
+++ b/src/main/java/piglin/swapswap/domain/deal/service/DealServiceImplV1.java
@@ -84,6 +84,11 @@ public class DealServiceImplV1 implements DealService {
             throw new RuntimeException("딜을 수정할 수 없는 상태입니다~");
         }
 
+        if (dealWalletService.existsDealWallet(dealId)) {
+
+            dealWalletService.withdrawMemberSwapMoneyAtDealUpdate(deal);
+        }
+
         if (deal.getFirstUserId().equals(memberId)) {
             DealMapper.updateDealFirst(deal, requestDto);
         }
@@ -202,7 +207,7 @@ public class DealServiceImplV1 implements DealService {
         if(deal.getFirstTake() && deal.getSecondTake()) {
 
             dealWalletService.withdrawMemberSwapMoneyAtComplete(deal);
-            
+
             deal.updateDealStatus(DealStatus.COMPLETED);
 
             List<Long> postIdList = new ArrayList<>();

--- a/src/main/java/piglin/swapswap/domain/deal/service/DealServiceImplV1.java
+++ b/src/main/java/piglin/swapswap/domain/deal/service/DealServiceImplV1.java
@@ -19,7 +19,6 @@ import piglin.swapswap.domain.member.entity.Member;
 import piglin.swapswap.domain.member.repository.MemberRepository;
 import piglin.swapswap.domain.post.service.PostService;
 import piglin.swapswap.domain.wallet.service.WalletService;
-import piglin.swapswap.domain.wallethistory.constant.HistoryType;
 import piglin.swapswap.global.exception.common.BusinessException;
 import piglin.swapswap.global.exception.common.ErrorCode;
 
@@ -32,7 +31,6 @@ public class DealServiceImplV1 implements DealService {
     private final MemberRepository memberRepository;
     private final DealWalletService dealWalletService;
     private final PostService postService;
-    private final WalletService walletService;
 
     @Override
     public Long createDeal(Member member, DealCreateRequestDto requestDto) {

--- a/src/main/java/piglin/swapswap/domain/deal/service/DealServiceImplV1.java
+++ b/src/main/java/piglin/swapswap/domain/deal/service/DealServiceImplV1.java
@@ -200,6 +200,9 @@ public class DealServiceImplV1 implements DealService {
         }
 
         if(deal.getFirstTake() && deal.getSecondTake()) {
+
+            dealWalletService.withdrawMemberSwapMoneyAtComplete(deal);
+            
             deal.updateDealStatus(DealStatus.COMPLETED);
 
             List<Long> postIdList = new ArrayList<>();

--- a/src/main/java/piglin/swapswap/domain/post/mapper/PostMapper.java
+++ b/src/main/java/piglin/swapswap/domain/post/mapper/PostMapper.java
@@ -38,7 +38,7 @@ public class PostMapper {
 
     public static List<PostSimpleResponseDto> getPostSimpleInfoListByPostList(List<Post> postList) {
 
-        return postList.stream().map((post) -> PostSimpleResponseDto.builder()
+        return  postList.stream().filter(post -> post.getDealStatus().equals(DealStatus.REQUESTED)).map((post) -> PostSimpleResponseDto.builder()
                         .postId(post.getId())
                         .postTitle(post.getTitle())
                         .imageUrl(post.getImageUrl().get(0).toString())

--- a/src/main/java/piglin/swapswap/domain/wallet/controller/WalletController.java
+++ b/src/main/java/piglin/swapswap/domain/wallet/controller/WalletController.java
@@ -58,9 +58,11 @@ public class WalletController {
             WithdrawSwapMoneyRequestDto withdrawSwapMoneyRequestDto,
             @AuthMember Member member) {
 
-        walletService.withdrawSwapMoney(withdrawSwapMoneyRequestDto.swapMoney(),
-                HistoryType.NORMAL_WITHDRAW,
-                member.getId());
+        if (withdrawSwapMoneyRequestDto.swapMoney() != null) {
+            walletService.withdrawSwapMoney(withdrawSwapMoneyRequestDto.swapMoney(),
+                    HistoryType.NORMAL_WITHDRAW,
+                    member.getId());
+        }
 
         return "redirect:/members/swap-money";
     }

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -10,6 +10,7 @@ spring:
       ddl-auto: update
     properties:
       hibernate:
+        show_sql: true
     open-in-view: false
 
   servlet:

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -1352,32 +1352,28 @@ input[type="number"] {
 }
 
 .deal-card {
-  width: 1375px;
+  width: 80%;
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
   border-radius: 8px;
-  margin-left: 500px;
-  margin-right: 50px;
-  margin-top: 100px;
+  margin: 0 auto;
 }
 
 .deal-response-card {
-  width: 1375px;
+  width: 80%;
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
   border-radius: 8px;
-  margin-right: 50px;
-  margin-top: 100px;
+  margin: 0 auto;
 }
 
 .deal-card-body {
-  margin-left: 20px;
   display: flex;
   flex-direction: row;
   justify-content: space-between;
-  align-items: center;
+  margin: 0 auto;
 }
 
 .deal-response-card-body {
-  margin-left: 20px;
+  margin: 0 auto;
   display: flex;
   flex-direction: row;
   justify-content: space-between;
@@ -1398,12 +1394,13 @@ input[type="number"] {
 .deal-request-List {
   display: flex;
   flex-direction: column;
+  margin: 0 auto;
 }
 
 .deal-response-List {
   display: flex;
   flex-direction: column;
-  margin-left: 500px;
+  margin: 0 auto;
 }
 
 .swap-money-body {
@@ -1460,7 +1457,8 @@ input[type="number"] {
 }
 
 .deal-status {
-  margin-left: 350px; /* 원하는 간격으로 조정하세요. */
+  margin-left: auto;
+  margin-right: 10px;/* 원하는 간격으로 조정하세요. */
   /* 원하는 스타일 속성을 추가하세요. */
 }
 .deal-detail-status{
@@ -1472,11 +1470,41 @@ input[type="number"] {
   padding: 10px;
   display: inline-block;
   background-color: #00aadc;
-  width: 110px;
+  width: 5%;
   color: white;
   box-shadow: 2px 2px 20px rgba(0, 0, 0, .3);
-  margin-left: 10px;
   text-decoration: none;
+  height: 5%;
+  margin-top: 12px;
+  text-align: center;
+}
+
+.deal-history-button {
+  border: 2px solid #ccc;
+  border-radius: 40px;
+  padding: 10px;
+  display: inline-block;
+  background-color: #00aadc;
+  color: white;
+  box-shadow: 2px 2px 20px rgba(0, 0, 0, .3);
+  text-decoration: none;
+  height: 5%;
+  margin-top: 12px;
+  text-align: center;
+}
+
+.deal-responseList-button {
+  border: 2px solid #ccc;
+  border-radius: 40px;
+  padding: 10px;
+  display: inline-block;
+  background-color: #00aadc;
+  width: 5%;
+  color: white;
+  box-shadow: 2px 2px 20px rgba(0, 0, 0, .3);
+  text-decoration: none;
+  height: 5%;
+  text-align: center;
 }
 
 .deal-card-body a:hover {
@@ -1485,9 +1513,9 @@ input[type="number"] {
 }
 
 .deal-list {
-  width: 1500px;
+  width: 80%;
   border-bottom: solid #808080;
-  margin-left: 500px;
+  margin: 0 auto;
   display: flex;
   flex-direction: column;
 }
@@ -1512,7 +1540,6 @@ input[type="number"] {
   box-shadow: 2px 2px 20px rgba(0, 0, 0, .3);
   text-decoration: none;
   margin-left: auto;
-  margin-right: 10px;
   height: 20px;
 }
 
@@ -1828,54 +1855,47 @@ input[type="number"] {
 }
 
 .deal-history-all-body {
-  width: 1375px;
+  width: 80%;
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
   border-radius: 8px;
-  margin-left: 500px;
-  margin-right: 50px;
-  margin-top: 100px;
+  margin: 0 auto;
+  margin-top: 50px;
 }
 
-.deal-history-all-body .deal-history-body {
-  margin-left: 20px;
+.deal-history-body {
   display: flex;
   flex-direction: row;
   justify-content: space-between;
   align-items: center;
+  margin: 0 auto;
 }
 
-.deal-history-all-body .deal-history-body h2 {
+.deal-history-body h2 {
   margin: 0;
 }
 
 
 .deal-card2-body{
-  margin-left: 20px;
   display: flex;
   flex-direction: row;
   align-items: center;
-}
-
-.deal-content{
-  margin-left: 10%;
+  justify-content: space-between;
 }
 
 .deal-history-created{
-  width: 200px;
+  width: 210px;
 }
 
 .deal-history-completed{
-  width: 200px;
-  margin-left: 170px;
+  width: 210px;
+  margin-right: 120px;
 }
 
 .deal-history-status {
   width: 100px;
-  margin-left: 235px;
-  text-align: center;
+  margin-right: 190px;
 }
 
 .deal-history-detail {
-  width: 100px;
-  margin-left: 300px;
+  width: 134px;
 }

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -1898,7 +1898,7 @@ input[type="number"] {
 
 .deal-history-completed{
   width: 210px;
-  margin-right: 120px;
+  margin-right: 38px;
 }
 
 .deal-history-status {

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -1461,9 +1461,18 @@ input[type="number"] {
   margin-right: 10px;/* 원하는 간격으로 조정하세요. */
   /* 원하는 스타일 속성을 추가하세요. */
 }
+
 .deal-detail-status{
-  margin-left: 20px;
+  background-color: white;
+  border-radius: 30px;
+  margin-left: auto;
+  padding: 15px;
 }
+
+.deal-detail-nickname{
+  padding: 15px;
+}
+
 .deal-button {
   border: 2px solid #ccc;
   border-radius: 40px;
@@ -1657,6 +1666,7 @@ input[type="number"] {
   color: #fff; /* Example header text color */
   padding: 20px;
   font-size: 1.5rem;
+  display: flex;
 }
 
 /* Flex container for deal content */

--- a/src/main/resources/templates/deal/dealHistory.html
+++ b/src/main/resources/templates/deal/dealHistory.html
@@ -5,7 +5,7 @@
 <link rel="stylesheet" type="text/css" href="your-stylesheet.css">
 
 <body>
-<div class="deal-content" layout:fragment="content">
+<div layout:fragment="content">
   <div class="deal-list">
     <div class="author-dealList-name" th:text="${memberNickname}+'님의 거래 내역'">
     </div>
@@ -22,10 +22,10 @@
       </div>
       <div th:each="dealHistoryDto : ${dealHistoryResponseDto}" class="deal-card">
         <div class="deal-card2-body">
-         <div class="deal-history-created" ><h2 class="deal-createdTime" th:text="${#temporals.format(dealHistoryDto.createdTime(), 'yyyy-MM-dd')}"></h2></div>
-          <div class="deal-history-completed" ><h2 th:if="${dealHistoryDto.completedDealTime != null}" th:text="${#temporals.format(dealHistoryDto.completedDealTime, 'yyyy-MM-dd')}"></h2></div>
+         <div class="deal-history-created" ><h2 class="deal-createdTime" th:text="${#temporals.format(dealHistoryDto.createdTime(), 'yyyy-MM-dd HH:mm')}"></h2></div>
+          <div class="deal-history-completed" ><h2 th:if="${dealHistoryDto.completedDealTime != null}" th:text="${#temporals.format(dealHistoryDto.completedDealTime, 'yyyy-MM-dd HH:mm')}"></h2></div>
           <div class="deal-history-status"><h2 th:text="${dealHistoryDto.dealStatus().getName()}"></h2></div>
-          <div class="deal-history-detail"><a th:href="@{/deals/{dealId}(dealId=${dealHistoryDto.id()})}" class="deal-button">거래 상세 보기</a></div>
+          <div class="deal-history-detail"><a th:href="@{/deals/{dealId}(dealId=${dealHistoryDto.id()})}" class="deal-history-button">거래 상세 보기</a></div>
         </div>
       </div>
     </div>

--- a/src/main/resources/templates/deal/dealRequestDeal.html
+++ b/src/main/resources/templates/deal/dealRequestDeal.html
@@ -6,11 +6,11 @@
 <body>
 <div layout:fragment="content">
   <input type="hidden" th:value="${dealId}" class="deal-id">
-  <h2 th:text="${dealDetailResponseDto.dealStatus.getName}" class="deal-detail-status"></h2>
   <div class="deal-detail-card">
     <div class="deal-detail-card-body">
       <h2 th:text="${dealDetailResponseDto.firstUserNickname}+'의 스왑 요청 !'"
           class="deal-detail-nickname"></h2>
+      <h2 th:text="${dealDetailResponseDto.dealStatus.getName}" class="deal-detail-status"></h2>
     </div>
     <div class="deal-detail-content-container">
       <div class="deal-detail-request-list">
@@ -69,7 +69,7 @@
   <script th:inline="javascript">
     const dealIdElement = document.querySelector('.deal-id');
     const dealId = +dealIdElement.value;
-    var useUrl = '/deals/' + dealId + '/use'
+    var swapMoneyUrl = '/deals/' + dealId + '/swapmoney'
     var allowUrl = '/deals/' + dealId + '/allow'
     var takeUrl = '/deals/' + dealId + '/take'
 
@@ -106,7 +106,7 @@
 
     function swapMoneyUse() {
       $.ajax({
-        url: useUrl,
+        url: swapMoneyUrl,
         type: 'PATCH',
         success: function () {
           location.reload();

--- a/src/main/resources/templates/deal/dealRequestDeal.html
+++ b/src/main/resources/templates/deal/dealRequestDeal.html
@@ -30,6 +30,7 @@
           </a>
           </div>
           <div class="deal-acceptance-buttons">
+            <button class="deal-acceptance-button" th:if="${memberId==dealDetailResponseDto.firstUserId()}" th:text="${dealDetailResponseDto.isFirstSwapMoneyUsed()} ? '스왑페이 사용 취소' : '스왑페이 사용'"  onclick="swapMoneyUse()"></button>
             <button th:if="${dealDetailResponseDto.dealStatus()==dealDetailResponseDto.dealStatus().REQUESTED&&memberId==dealDetailResponseDto.firstUserId()}" class="deal-acceptance-button" th:text="${dealDetailResponseDto.firstAllow} ? '수락취소하기' : '수락하기'"  onclick="dealAllow()"></button>
             <button th:if="${dealDetailResponseDto.dealStatus()==dealDetailResponseDto.dealStatus().DEALING&&memberId==dealDetailResponseDto.firstUserId()}" class="deal-acceptance-button" onclick="dealTake()">거래 인수하기</button>
           </div>
@@ -49,6 +50,7 @@
             수정하기</a>
           </div>
           <div class="deal-acceptance-buttons">
+            <button class="deal-acceptance-button" th:if="${memberId==dealDetailResponseDto.secondUserId()}" th:text="${dealDetailResponseDto.isSecondSwapMoneyUsed()} ? '스왑페이 사용 취소' : '스왑페이 사용'"  onclick="swapMoneyUse()"></button>
             <button th:if="${dealDetailResponseDto.dealStatus()==dealDetailResponseDto.dealStatus().REQUESTED&&memberId==dealDetailResponseDto.secondUserId()}" class="deal-acceptance-button" th:text="${dealDetailResponseDto.secondAllow()} ? '수락취소하기' : '수락하기'"  onclick="dealAllow()"></button>
             <button th:if="${dealDetailResponseDto.dealStatus()==dealDetailResponseDto.dealStatus().DEALING&&memberId==dealDetailResponseDto.secondUserId()}" class="deal-acceptance-button" onclick="dealTake()">거래 인수하기</button>
           </div>
@@ -61,7 +63,7 @@
   <script th:inline="javascript">
     const dealIdElement = document.querySelector('.deal-id');
     const dealId = +dealIdElement.value;
-
+    var useUrl = '/deals/' + dealId + '/use'
     var allowUrl = '/deals/' + dealId + '/allow'
     var takeUrl = '/deals/' + dealId + '/take'
 
@@ -91,6 +93,21 @@
         error: function (xhr, status, error) {
           // 에러 처리
           alert("수락 할 수 없는 상태입니다.")
+          console.error("Update failed:", status, error);
+        }
+      })
+    }
+
+    function swapMoneyUse() {
+      $.ajax({
+        url: useUrl,
+        type: 'PATCH',
+        success: function () {
+          location.reload();
+        },
+        error: function (xhr, status, error) {
+          // 에러 처리
+          alert("스왑페이 사용여부를 변경 할 수 없는 상태입니다.")
           console.error("Update failed:", status, error);
         }
       })

--- a/src/main/resources/templates/deal/dealRequestDeal.html
+++ b/src/main/resources/templates/deal/dealRequestDeal.html
@@ -23,6 +23,9 @@
           <div class="deal-take-status">인수 상태:
             <div  class="deal-detail-take" th:text=" ${dealDetailResponseDto.firstTake} ? '인수 완료' : '인수 대기'"></div>
           </div>
+          <div class="deal-swap-pay-status">스왑페이 사용여부:
+            <div class="deal-detail-take" th:text=" ${dealDetailResponseDto.isFirstSwapMoneyUsed()} ? '스왑페이 사용' : '스왑페이 미사용'"></div>
+          </div>
             <img th:each="firstMemberPost : ${firstMemberPostList}" th:src="${firstMemberPost.imageUrl}" alt="Post Image" class="deal-detail-post-image">
           <div class="deal-detail-first-user-edit-button" th:if="${dealDetailResponseDto.dealStatus()==dealDetailResponseDto.dealStatus().REQUESTED}"> <a
                th:href="@{/deals/{id}/member/{userId}(id=${dealDetailResponseDto.id}, userId=${dealDetailResponseDto.firstUserId})}">
@@ -42,8 +45,11 @@
           <div class="deal-detail-allow "th:text= "${dealDetailResponseDto.secondAllow} ? '수락 완료' : '수락 대기'"></div>
           </div>
             <div class="deal-take-status">인수 상태:
-          <div  class="deal-detail-take" th:text=" ${dealDetailResponseDto.secondTake} ? '인수 완료' : '인수 대기'"></div>
+          <div class="deal-detail-take" th:text=" ${dealDetailResponseDto.secondTake} ? '인수 완료' : '인수 대기'"></div>
             </div>
+          <div class="deal-swap-pay-status">스왑페이 사용여부:
+            <div class="deal-detail-take" th:text=" ${dealDetailResponseDto.isSecondSwapMoneyUsed()} ? '스왑페이 사용' : '스왑페이 미사용'"></div>
+          </div>
               <img th:each="secondMemberPost : ${secondMemberPostList}" th:src="${secondMemberPost.imageUrl}" alt="Post Image" class="deal-detail-post-image">
           <div class="deal-detail-second-user-edit-button" th:if="${dealDetailResponseDto.dealStatus()==dealDetailResponseDto.dealStatus().REQUESTED}"> <a
                th:href="@{/deals/{id}/member/{userId}(id=${dealDetailResponseDto.id}, userId=${dealDetailResponseDto.secondUserId})}">

--- a/src/main/resources/templates/deal/dealRequestDeal.html
+++ b/src/main/resources/templates/deal/dealRequestDeal.html
@@ -16,7 +16,7 @@
       <div class="deal-detail-request-list">
         <div class="deal-detail-list-container">
           <div th:text="${dealDetailResponseDto.firstUserNickname}+'님의 스왑 물품'" class="deal-detail-post"></div>
-          <div th:text="'추가금: ' + ${dealDetailResponseDto.firstExtraFee()}" class="deal-detail-ExtraFee"></div>
+          <div th:text="${dealDetailResponseDto.firstExtraFee() != null ? '추가금: ' + dealDetailResponseDto.firstExtraFee() : '추가금: 0'}" class="deal-detail-ExtraFee"></div>
           <div class="deal-allow-status">수락 상태:
           <div class="deal-detail-allow" th:text="${dealDetailResponseDto.firstAllow} ? '수락 완료' : '수락 대기'"></div>
           </div>
@@ -33,14 +33,14 @@
           </a>
           </div>
           <div class="deal-acceptance-buttons">
-            <button class="deal-acceptance-button" th:if="${memberId==dealDetailResponseDto.firstUserId()}" th:text="${dealDetailResponseDto.isFirstSwapMoneyUsed()} ? '스왑페이 사용 취소' : '스왑페이 사용'"  onclick="swapMoneyUse()"></button>
+            <button class="deal-acceptance-button" th:if="${memberId==dealDetailResponseDto.firstUserId()&&dealDetailResponseDto.firstExtraFee() != null}" th:text="${dealDetailResponseDto.isFirstSwapMoneyUsed()} ? '스왑페이 사용 취소' : '스왑페이 사용'"  onclick="swapMoneyUse()"></button>
             <button th:if="${dealDetailResponseDto.dealStatus()==dealDetailResponseDto.dealStatus().REQUESTED&&memberId==dealDetailResponseDto.firstUserId()}" class="deal-acceptance-button" th:text="${dealDetailResponseDto.firstAllow} ? '수락취소하기' : '수락하기'"  onclick="dealAllow()"></button>
             <button th:if="${dealDetailResponseDto.dealStatus()==dealDetailResponseDto.dealStatus().DEALING&&memberId==dealDetailResponseDto.firstUserId()}" class="deal-acceptance-button" onclick="dealTake()">거래 인수하기</button>
           </div>
         </div>
         <div class="deal-detail-list-container">
           <div th:text="${dealDetailResponseDto.secondUserNickname}+'님의 스왑 물품'" class="deal-detail-post"></div>
-          <div th:text="'추가금: ' + ${dealDetailResponseDto.secondExtraFee}" class="deal-detail-ExtraFee"></div>
+          <div th:text="${dealDetailResponseDto.secondExtraFee() != null ? '추가금: ' + dealDetailResponseDto.secondExtraFee() : '추가금: 0'}" class="deal-detail-ExtraFee"></div>
           <div class="deal-allow-status">수락 상태:
           <div class="deal-detail-allow "th:text= "${dealDetailResponseDto.secondAllow} ? '수락 완료' : '수락 대기'"></div>
           </div>
@@ -56,7 +56,7 @@
             수정하기</a>
           </div>
           <div class="deal-acceptance-buttons">
-            <button class="deal-acceptance-button" th:if="${memberId==dealDetailResponseDto.secondUserId()}" th:text="${dealDetailResponseDto.isSecondSwapMoneyUsed()} ? '스왑페이 사용 취소' : '스왑페이 사용'"  onclick="swapMoneyUse()"></button>
+            <button class="deal-acceptance-button" th:if="${memberId==dealDetailResponseDto.secondUserId()&&dealDetailResponseDto.secondExtraFee() != null}" th:text="${dealDetailResponseDto.isSecondSwapMoneyUsed()} ? '스왑페이 사용 취소' : '스왑페이 사용'"  onclick="swapMoneyUse()"></button>
             <button th:if="${dealDetailResponseDto.dealStatus()==dealDetailResponseDto.dealStatus().REQUESTED&&memberId==dealDetailResponseDto.secondUserId()}" class="deal-acceptance-button" th:text="${dealDetailResponseDto.secondAllow()} ? '수락취소하기' : '수락하기'"  onclick="dealAllow()"></button>
             <button th:if="${dealDetailResponseDto.dealStatus()==dealDetailResponseDto.dealStatus().DEALING&&memberId==dealDetailResponseDto.secondUserId()}" class="deal-acceptance-button" onclick="dealTake()">거래 인수하기</button>
           </div>
@@ -79,7 +79,7 @@
       var statusName = element.textContent.trim();
       var statusColors = {
         '요청 중': '#FF0000',
-        '거래 중': '#00AADC',
+        '거래 진행 중': '#00AADC',
         '거래 완료': '#000000'
       };
 

--- a/src/main/resources/templates/deal/dealRequestDealListForm.html
+++ b/src/main/resources/templates/deal/dealRequestDealListForm.html
@@ -4,7 +4,7 @@
       layout:decorate="~{common/layout/layout}">
 <link rel="stylesheet" type="text/css" href="your-stylesheet.css">
 <body>
-<div style="margin-left: 10%;" layout:fragment="content">
+<div layout:fragment="content">
   <div class="deal-list">
   <div class="author-dealList-name" th:text="${memberNickname}+'님의 스왑 요청 목록'">
   </div>

--- a/src/main/resources/templates/deal/dealResponseDealListForm.html
+++ b/src/main/resources/templates/deal/dealResponseDealListForm.html
@@ -4,7 +4,7 @@
       layout:decorate="~{common/layout/layout}">
 <link rel="stylesheet" type="text/css" href="your-stylesheet.css">
 <body>
-<div style="margin-left: 10%;" layout:fragment="content">
+<div layout:fragment="content">
   <div class="deal-list">
     <div class="author-dealList-name" th:text="${memberNickname}+'님이 받은 스왑 요청 목록'">
   </div>
@@ -15,7 +15,7 @@
         <div class="deal-response-card-body">
           <h2 th:text="${dealDto.secondUserNickname()} +'님이 요청한 거래'" class="deal-nickname"></h2>
           <h2 th:text="${dealDto.dealStatus().getName()}" class="deal-status"></h2>
-          <a th:href="@{/deals/{dealId}(dealId=${dealDto.dealId})}" class="deal-button">거래 요청 보기</a>
+          <a th:href="@{/deals/{dealId}(dealId=${dealDto.dealId})}" class="deal-responseList-button">거래 요청 보기</a>
         </div>
       </div>
     </div>

--- a/src/main/resources/templates/member/login.html
+++ b/src/main/resources/templates/member/login.html
@@ -17,7 +17,7 @@
         로그인
       </h2>
       <div class="actions">
-        <a href="https://kauth.kakao.com/oauth/authorize?client_id=a304535271497a06332e50e9eec191ab&redirect_uri=http://swapswap.shop/login/kakao/callback&response_type=code">
+        <a href="https://kauth.kakao.com/oauth/authorize?client_id=a304535271497a06332e50e9eec191ab&redirect_uri=http://localhost:8080/login/kakao/callback&response_type=code">
           <img src="/images/kakaologinlogo.png" alt="Kakao Logo">
           <p>카카오로 간편 로그인</p>
         </a>

--- a/src/main/resources/templates/member/login.html
+++ b/src/main/resources/templates/member/login.html
@@ -17,7 +17,7 @@
         로그인
       </h2>
       <div class="actions">
-        <a href="https://kauth.kakao.com/oauth/authorize?client_id=a304535271497a06332e50e9eec191ab&redirect_uri=http://localhost:8080/login/kakao/callback&response_type=code">
+        <a href="https://kauth.kakao.com/oauth/authorize?client_id=a304535271497a06332e50e9eec191ab&redirect_uri=http://swapswap.shop/login/kakao/callback&response_type=code">
           <img src="/images/kakaologinlogo.png" alt="Kakao Logo">
           <p>카카오로 간편 로그인</p>
         </a>


### PR DESCRIPTION
## 📝 개요
- 스왑 페이와 거래 연동 기능 구현
<br>

## 👨‍💻 작업 내용
- DealWallet 테이블 추가 및 스왑머니 사용 여부에 따른거래 수락 시 지갑에서 스왑머니 출금 입금 기능 구현,  거래 인수 시 각 지갑에 DealWallet에 있던 금액을 입금합니다.
- 거래 수정 시 거래 수락 취소에 따른 DealWallet에 있는 돈을 원래 주인의 지갑으로 돌려주고 DealWallet 삭제합니다.
<br>

## 🙇🏻‍♂️ 리뷰어에게
- 코드 컨벤션에 어긋나는 부분이나 오류 부분을  봐주셨으면 좋겠고 스왑페이 사용 부분을 중점으로 봐주시면 감사하겠습니다.
<br>
