### PR TITLE
Fix: 채팅방 마지막 메시지와 시간이 업데이트되지 않는 버그 해결

### DIFF
--- a/src/main/java/piglin/swapswap/domain/chatroom/entity/ChatRoom.java
+++ b/src/main/java/piglin/swapswap/domain/chatroom/entity/ChatRoom.java
@@ -13,7 +13,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.DynamicUpdate;
 import piglin.swapswap.domain.common.BaseTime;
-import piglin.swapswap.domain.message.dto.request.MessageRequestDto;
 
 @Entity
 @Getter
@@ -40,8 +39,8 @@ public class ChatRoom extends BaseTime {
         isDeleted = true;
     }
 
-    public void updateChatRoom(MessageRequestDto requestDto) {
-        this.lastMessage = requestDto.text();
+    public void updateChatRoom(String lastMessage) {
+        this.lastMessage = lastMessage;
         this.lastMessageTime = LocalDateTime.now();
     }
 }

--- a/src/main/java/piglin/swapswap/domain/chatroom/mapper/ChatRoomMapper.java
+++ b/src/main/java/piglin/swapswap/domain/chatroom/mapper/ChatRoomMapper.java
@@ -1,8 +1,6 @@
 package piglin.swapswap.domain.chatroom.mapper;
 
-import java.util.UUID;
 import piglin.swapswap.domain.chatroom.entity.ChatRoom;
-import piglin.swapswap.domain.message.dto.request.MessageRequestDto;
 
 public class ChatRoomMapper {
 
@@ -11,11 +9,6 @@ public class ChatRoomMapper {
         return ChatRoom.builder()
                 .isDeleted(false)
                 .build();
-    }
-
-    public static void updateChatRoom(ChatRoom chatRoom, MessageRequestDto requestDto) {
-
-        chatRoom.updateChatRoom(requestDto);
     }
 
 }

--- a/src/main/java/piglin/swapswap/domain/chatroom/service/ChatRoomServiceImpl.java
+++ b/src/main/java/piglin/swapswap/domain/chatroom/service/ChatRoomServiceImpl.java
@@ -1,5 +1,6 @@
 package piglin.swapswap.domain.chatroom.service;
 
+import jakarta.transaction.Transactional;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -54,6 +55,7 @@ public class ChatRoomServiceImpl implements ChatRoomService {
     }
 
     @Override
+    @Transactional
     public void saveMessage(MessageRequestDto requestDto) {
 
         ChatRoom chatRoom = getChatRoomByMessageDto(requestDto);
@@ -99,7 +101,7 @@ public class ChatRoomServiceImpl implements ChatRoomService {
     private Message createMessageAndUpdateLastMessage(ChatRoom chatRoom, MessageRequestDto requestDto) {
 
         Message message = MessageMapper.createMessage(requestDto, chatRoom);
-        ChatRoomMapper.updateChatRoom(chatRoom, requestDto);
+        chatRoom.updateChatRoom(requestDto.text());
 
         return message;
     }


### PR DESCRIPTION
## 📝 개요
- 채팅방 마지막 메시지와 시간이 업데이트되지 않는 버그 해결
<br>

## 👨‍💻 작업 내용
- @Transactional 누락으로 인한 변경감지 불가
- 이를 해결하기 위해 @Transactional 추가
<br>
