### PR TITLE
Refactor: 거래 수락 파트 긴 코드 메서드화 및 쿼리 최적화

### DIFF
--- a/src/main/java/piglin/swapswap/domain/post/repository/PostQueryRepository.java
+++ b/src/main/java/piglin/swapswap/domain/post/repository/PostQueryRepository.java
@@ -2,6 +2,7 @@ package piglin.swapswap.domain.post.repository;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import piglin.swapswap.domain.deal.constant.DealStatus;
 import piglin.swapswap.domain.member.entity.Member;
 import piglin.swapswap.domain.post.constant.Category;
 import piglin.swapswap.domain.post.constant.City;
@@ -24,4 +25,6 @@ public interface PostQueryRepository {
             LocalDateTime cursorTime);
 
     List<PostGetListResponseDto> findAllMyPostList(Member member, LocalDateTime cursorTime);
+
+    void updatePostListStatus(List<Long> postIdList, DealStatus dealStatus);
 }

--- a/src/main/java/piglin/swapswap/domain/post/repository/PostQueryRepositoryImpl.java
+++ b/src/main/java/piglin/swapswap/domain/post/repository/PostQueryRepositoryImpl.java
@@ -3,7 +3,6 @@ package piglin.swapswap.domain.post.repository;
 import static piglin.swapswap.domain.favorite.entity.QFavorite.favorite;
 import static piglin.swapswap.domain.post.entity.QPost.post;
 
-import com.querydsl.core.types.ExpressionUtils;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
@@ -13,6 +12,7 @@ import jakarta.persistence.EntityManager;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.stereotype.Repository;
+import piglin.swapswap.domain.deal.constant.DealStatus;
 import piglin.swapswap.domain.member.entity.Member;
 import piglin.swapswap.domain.member.entity.QMember;
 import piglin.swapswap.domain.post.constant.Category;
@@ -175,6 +175,19 @@ public class PostQueryRepositoryImpl implements PostQueryRepository {
                 .orderBy(post.modifiedUpTime.desc(), post.id.desc())
                 .limit(12)
                 .fetch();
+    }
+
+    @Override
+    public void updatePostListStatus(List<Long> postIdList, DealStatus dealStatus) {
+
+        queryFactory
+                .update(post)
+                .set(post.dealStatus, dealStatus)
+                .where(post.id.in(postIdList))
+                .execute();
+
+        em.flush();
+        em.clear();
     }
 
     private BooleanExpression lessThanCursorTime(LocalDateTime cursorTime) {

--- a/src/main/java/piglin/swapswap/domain/post/service/PostServiceImplV1.java
+++ b/src/main/java/piglin/swapswap/domain/post/service/PostServiceImplV1.java
@@ -237,10 +237,7 @@ public class PostServiceImplV1 implements PostService {
     @Override
     public void updatePostStatusByPostIdList(List<Long> postIdList, DealStatus dealStatus) {
 
-        for (Long postId : postIdList) {
-            Post post = findPost(postId);
-            post.updatePostDealStatus(dealStatus);
-        }
+        postRepository.updatePostListStatus(postIdList, dealStatus);
     }
 
     @Override


### PR DESCRIPTION
## 📝 개요
- 거래 수락 파트 긴 코드 메서드화 및 쿼리 최적화
<br>

## 👨‍💻 작업 내용
- 거래 수락 메서드가 if문이 많아 메서드로 추출해 메인 코드 부분을 줄였습니다.
- 여러 개의 게시물을 거래 진행 상태로 바꾸는 쿼리에서 조회 n개 쿼리 + 업데이트 n개 쿼리를 
- querydsl을 이용한 하나의 동적 쿼리로 해결하였습니다.
<br>

## 🙇🏻‍♂️ 리뷰어에게
- 기존의 코드를 메서드로 추출해 메인 코드 메서드의 줄 수를 줄였습니다. 테스트 결과 정상적으로 나옵니다.
<br>
