### PR TITLE
fix: TimeZone 설정 제거

### DIFF
--- a/src/main/java/piglin/swapswap/SwapswapApplication.java
+++ b/src/main/java/piglin/swapswap/SwapswapApplication.java
@@ -1,17 +1,10 @@
 package piglin.swapswap;
 
-import jakarta.annotation.PostConstruct;
-import java.util.TimeZone;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
 public class SwapswapApplication {
-
-	@PostConstruct
-	void init() {
-		TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
-	}
 
 	public static void main(String[] args) {
 		SpringApplication.run(SwapswapApplication.class, args);


### PR DESCRIPTION
## 📝 개요
- Docker에서 TimeZone 설정을 하여 Spring 자체에선 TimeZone 설정이 불필요해졌습니다.
<br>

## 👨‍💻 작업 내용
- Application TimeZone 설정 제거
<br>

## 🙇🏻‍♂️ 리뷰어에게
- 바로 머지하겠습니다!
<br>
