### PR TITLE
fix: 게시글 단 건 조회 시 DealStatus 사진 뒤에 가려지던 오류 해결

### DIFF
--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -536,6 +536,10 @@ img {
   object-fit: scale-down; /* 이미지가 컨테이너를 채우도록 하면서 비율을 유지 */
 }
 
+.post-content-image.activeDeal {
+  filter: brightness(40%);
+}
+
 /* 슬라이더의 이전/다음 버튼 */
 .post-slider-button {
   position: absolute;

--- a/src/main/resources/templates/post/post.html
+++ b/src/main/resources/templates/post/post.html
@@ -8,17 +8,17 @@
 <div layout:fragment="content">
   <div class="post-content-container">
     <div class="post-content-image-container">
-      <div class="post-deal-status">
-        <div th:if="${postGetResponseDto.dealStatus == postGetResponseDto.dealStatus.DEALING}"
-             class="post-deal-status dealing"> 거래 진행 중
-        </div>
-        <div th:if="${postGetResponseDto.dealStatus == postGetResponseDto.dealStatus.COMPLETED}"
-             class="post-deal-status completed"> 거래 완료
-        </div>
-      </div>
       <div class="post-content-image-slider">
-        <img th:each="entry:${postGetResponseDto.imageUrl.entrySet}" th:src="${entry.value}"
+        <img th:if="${postGetResponseDto.dealStatus == postGetResponseDto.dealStatus.REQUESTED}"
+             th:each="entry:${postGetResponseDto.imageUrl.entrySet}" th:src="${entry.value}"
              th:alt="'Image '+ ${entry.key}" class="post-content-image">
+        <img th:unless="${postGetResponseDto.dealStatus == postGetResponseDto.dealStatus.REQUESTED}"
+             th:each="entry:${postGetResponseDto.imageUrl.entrySet}" th:src="${entry.value}"
+             th:alt="'Image '+ ${entry.key}" class="post-content-image activeDeal">
+        <div class="post-deal-status">
+          <div th:if="${postGetResponseDto.dealStatus == postGetResponseDto.dealStatus.DEALING}" class="post-deal-status dealing"> 거래 진행 중 </div>
+          <div th:if="${postGetResponseDto.dealStatus == postGetResponseDto.dealStatus.COMPLETED}" class="post-deal-status completed"> 거래 완료 </div>
+        </div>
       </div>
       <button class="post-slider-button post-prev-button" onclick="moveSlide(-1)">＜</button>
       <button class="post-slider-button post-next-button" onclick="moveSlide(1)">＞</button>


### PR DESCRIPTION
## 📝 개요
- 게시글 단 건 조회 시 DealStatus 사진 뒤에 가려지던 오류 해결
<br>

## 👨‍💻 작업 내용
- 게시글 단 건 조회 시 DealStatus 에 따라 사진 색 변경
- 게시글 거래 상태 이미지 뒤에 가려지던 오류 해결
<br>

## 🙇🏻‍♂️ 리뷰어에게
- 바로 머지하겠습니다.
<br>
