### PR TITLE
fix: 게시글 단 건 조회 시 DealStatus 사진 여러개면 엄청 길게 뜨는 오류 해결

### DIFF
--- a/src/main/resources/templates/post/post.html
+++ b/src/main/resources/templates/post/post.html
@@ -15,13 +15,11 @@
         <img th:unless="${postGetResponseDto.dealStatus == postGetResponseDto.dealStatus.REQUESTED}"
              th:each="entry:${postGetResponseDto.imageUrl.entrySet}" th:src="${entry.value}"
              th:alt="'Image '+ ${entry.key}" class="post-content-image activeDeal">
-        <div class="post-deal-status">
-          <div th:if="${postGetResponseDto.dealStatus == postGetResponseDto.dealStatus.DEALING}" class="post-deal-status dealing"> 거래 진행 중 </div>
-          <div th:if="${postGetResponseDto.dealStatus == postGetResponseDto.dealStatus.COMPLETED}" class="post-deal-status completed"> 거래 완료 </div>
-        </div>
       </div>
       <button class="post-slider-button post-prev-button" onclick="moveSlide(-1)">＜</button>
       <button class="post-slider-button post-next-button" onclick="moveSlide(1)">＞</button>
+      <div th:if="${postGetResponseDto.dealStatus == postGetResponseDto.dealStatus.DEALING}" class="post-deal-status dealing"> 거래 진행 중 </div>
+      <div th:if="${postGetResponseDto.dealStatus == postGetResponseDto.dealStatus.COMPLETED}" class="post-deal-status completed"> 거래 완료 </div>
     </div>
     <div>
       <div class="post-content-details">


### PR DESCRIPTION
## 📝 개요
- 게시글 단 건 조회 시 게시글 완료 상태이고, 사진이 여러개면 DealStatus가 되게 이상하게 떴었습니다.
<br>

## 👨‍💻 작업 내용
- 게시글 단 건 조회 시 DealStatus 사진 여러개면 엄청 길게 뜨는 오류 해결
- 
![스크린샷 2024-01-25 오전 3 22 52](https://github.com/Team-Piglin/swapswap/assets/123870616/9f1d9a55-7630-4635-91ca-e607b37fcb92)

여기에서

![스크린샷 2024-01-25 오전 3 23 12](https://github.com/Team-Piglin/swapswap/assets/123870616/00691ae0-bb32-429b-ab38-90780be8862d)

이렇게 바꼈습니다.

<br>

## 🙇🏻‍♂️ 리뷰어에게
- 바로 머지하겠습니다~
<br>
