### PR TITLE
HOTFIX: ChatRoomMember isDeleted 필드 추가로 인한 버그 해결

### DIFF
--- a/src/main/java/piglin/swapswap/domain/chatroom_member/mapper/ChatRoomMemberMapper.java
+++ b/src/main/java/piglin/swapswap/domain/chatroom_member/mapper/ChatRoomMemberMapper.java
@@ -11,6 +11,7 @@ public class ChatRoomMemberMapper {
         return ChatRoomMember.builder()
                 .chatRoom(chatRoom)
                 .member(member)
+                .isDeleted(false)
                 .build();
     }
 


### PR DESCRIPTION
## 📝 개요
- ChatRoomMember isDeleted 필드 추가로 인한 버그 해결
<br>

## 👨‍💻 작업 내용
- 채팅 방 생성 시, ChatRoomMember엔티티를 만들 때,  ChatRoomMemberMapper에서 isDeleted 누락으로 인한 DB의 null 예외 발생
<br>