### PR TITLE
Refactor: 엔티티간 연관관계를 가능한 가지지 않는 방향으로 리팩토링

### DIFF
--- a/src/main/java/piglin/swapswap/domain/chatroom/controller/ChatRoomController.java
+++ b/src/main/java/piglin/swapswap/domain/chatroom/controller/ChatRoomController.java
@@ -38,15 +38,14 @@ public class ChatRoomController {
     @GetMapping("/chats/room/{roomId}")
     public String getChatRoom(
             @PathVariable Long roomId,
-            @RequestParam(name = "nickname", required = false) String nickname,
             @AuthMember Member member,
             Model model
     ) {
 
         List<MessageResponseDto> messageList = chatRoomService.getMessageByChatRoomId(roomId, member);
+        ChatRoomResponseDto chatRoom = chatRoomService.getChatRoomResponseDto(roomId, member.getId());
 
-        model.addAttribute("roomId", roomId);
-        model.addAttribute("nickname", nickname);
+        model.addAttribute("chatRoom", chatRoom);
         model.addAttribute("messageList", messageList);
 
         return "chat/chatroom";

--- a/src/main/java/piglin/swapswap/domain/chatroom/controller/ChatRoomController.java
+++ b/src/main/java/piglin/swapswap/domain/chatroom/controller/ChatRoomController.java
@@ -24,7 +24,10 @@ public class ChatRoomController {
     private final ChatRoomServiceImpl chatRoomService;
 
     @GetMapping("/chats")
-    public String getChatRoomList(@AuthMember Member member, Model model) {
+    public String getChatRoomList(
+            @AuthMember Member member,
+            Model model
+    ) {
 
         List<ChatRoomResponseDto> chatRoomList = chatRoomService.getChatRoomList(member);
         model.addAttribute("chatRoomList", chatRoomList);
@@ -33,12 +36,18 @@ public class ChatRoomController {
     }
 
     @GetMapping("/chats/room/{roomId}")
-    public String getChatRoom(@PathVariable Long roomId, @AuthMember Member member, Model model) {
+    public String getChatRoom(
+            @PathVariable Long roomId,
+            @RequestParam(name = "nickname", required = false) String nickname,
+            @AuthMember Member member,
+            Model model
+    ) {
 
         List<MessageResponseDto> messageList = chatRoomService.getMessageByChatRoomId(roomId, member);
 
-        model.addAttribute("messageList", messageList);
         model.addAttribute("roomId", roomId);
+        model.addAttribute("nickname", nickname);
+        model.addAttribute("messageList", messageList);
 
         return "chat/chatroom";
     }

--- a/src/main/java/piglin/swapswap/domain/chatroom/controller/ChatRoomController.java
+++ b/src/main/java/piglin/swapswap/domain/chatroom/controller/ChatRoomController.java
@@ -58,7 +58,9 @@ public class ChatRoomController {
             @RequestParam Long secondMemberId
     ) {
 
-        return chatRoomService.createChatroom(member, secondMemberId);
+        Long chatRoomId = chatRoomService.createChatroom(member, secondMemberId);
+
+        return chatRoomId;
     }
 
     @ResponseBody

--- a/src/main/java/piglin/swapswap/domain/chatroom/dto/ChatRoomResponseDto.java
+++ b/src/main/java/piglin/swapswap/domain/chatroom/dto/ChatRoomResponseDto.java
@@ -6,7 +6,7 @@ import lombok.Builder;
 @Builder
 public record ChatRoomResponseDto(
         Long id,
-        String username,
+        String nickname,
         String lastMessage,
         LocalDateTime lastMessageTime
 ) {

--- a/src/main/java/piglin/swapswap/domain/chatroom/entity/ChatRoom.java
+++ b/src/main/java/piglin/swapswap/domain/chatroom/entity/ChatRoom.java
@@ -55,6 +55,8 @@ public class ChatRoom extends BaseTime {
     }
 
     public void updateChatRoom(String lastMessage) {
+        this.isLeaveFirstMember = false;
+        this.isLeaveSecondMember = false;
         this.lastMessage = lastMessage;
         this.lastMessageTime = LocalDateTime.now();
     }

--- a/src/main/java/piglin/swapswap/domain/chatroom/entity/ChatRoom.java
+++ b/src/main/java/piglin/swapswap/domain/chatroom/entity/ChatRoom.java
@@ -13,6 +13,9 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.DynamicUpdate;
 import piglin.swapswap.domain.common.BaseTime;
+import piglin.swapswap.domain.member.entity.Member;
+import piglin.swapswap.global.exception.common.BusinessException;
+import piglin.swapswap.global.exception.common.ErrorCode;
 
 @Entity
 @Getter
@@ -25,6 +28,12 @@ public class ChatRoom extends BaseTime {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @Column(nullable = true)
+    private Long firstMemberId;
+
+    @Column(nullable = true)
+    private Long secondMemberId;
 
     @Column(nullable = true)
     private String lastMessage;
@@ -42,5 +51,19 @@ public class ChatRoom extends BaseTime {
     public void updateChatRoom(String lastMessage) {
         this.lastMessage = lastMessage;
         this.lastMessageTime = LocalDateTime.now();
+    }
+
+    public void leaveChatRoom(Member member) {
+
+        if (member.getId().equals(firstMemberId)) {
+
+            firstMemberId = null;
+        } else if (member.getId().equals(secondMemberId)) {
+
+            secondMemberId = null;
+        } else {
+
+            throw new BusinessException(ErrorCode.NOT_CHAT_ROOM_MEMBER_EXCEPTION);
+        }
     }
 }

--- a/src/main/java/piglin/swapswap/domain/chatroom/entity/ChatRoom.java
+++ b/src/main/java/piglin/swapswap/domain/chatroom/entity/ChatRoom.java
@@ -29,11 +29,17 @@ public class ChatRoom extends BaseTime {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = true)
+    @Column(nullable = false)
     private Long firstMemberId;
 
-    @Column(nullable = true)
+    @Column(nullable = false)
     private Long secondMemberId;
+
+    @Column(nullable = false)
+    private boolean isLeaveFirstMember;
+
+    @Column(nullable = false)
+    private boolean isLeaveSecondMember;
 
     @Column(nullable = true)
     private String lastMessage;
@@ -53,14 +59,24 @@ public class ChatRoom extends BaseTime {
         this.lastMessageTime = LocalDateTime.now();
     }
 
+    public void reentryFirstMember() {
+        isLeaveFirstMember = false;
+    }
+
+    public void reentrySecondMember() {
+        isLeaveSecondMember = false;
+    }
+
     public void leaveChatRoom(Member member) {
 
         if (member.getId().equals(firstMemberId)) {
 
-            firstMemberId = null;
+            isLeaveFirstMember = true;
+
         } else if (member.getId().equals(secondMemberId)) {
 
-            secondMemberId = null;
+            isLeaveSecondMember = true;
+
         } else {
 
             throw new BusinessException(ErrorCode.NOT_CHAT_ROOM_MEMBER_EXCEPTION);

--- a/src/main/java/piglin/swapswap/domain/chatroom/mapper/ChatRoomMapper.java
+++ b/src/main/java/piglin/swapswap/domain/chatroom/mapper/ChatRoomMapper.java
@@ -1,14 +1,22 @@
 package piglin.swapswap.domain.chatroom.mapper;
 
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import piglin.swapswap.domain.chatroom.dto.ChatRoomResponseDto;
 import piglin.swapswap.domain.chatroom.entity.ChatRoom;
+import piglin.swapswap.domain.member.entity.Member;
 
+@RequiredArgsConstructor
 public class ChatRoomMapper {
 
-    public static ChatRoom createChatRoom() {
+    public static ChatRoom createChatRoom(Member firstMember, Member secondMember) {
 
         return ChatRoom.builder()
+                .firstMemberId(firstMember.getId())
+                .secondMemberId(secondMember.getId())
                 .isDeleted(false)
                 .build();
     }
 
 }
+

--- a/src/main/java/piglin/swapswap/domain/chatroom/mapper/ChatRoomMapper.java
+++ b/src/main/java/piglin/swapswap/domain/chatroom/mapper/ChatRoomMapper.java
@@ -1,6 +1,5 @@
 package piglin.swapswap.domain.chatroom.mapper;
 
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import piglin.swapswap.domain.chatroom.dto.ChatRoomResponseDto;
 import piglin.swapswap.domain.chatroom.entity.ChatRoom;
@@ -13,9 +12,22 @@ public class ChatRoomMapper {
 
         return ChatRoom.builder()
                 .firstMemberId(firstMember.getId())
+                .isLeaveFirstMember(false)
                 .secondMemberId(secondMember.getId())
+                .isLeaveSecondMember(false)
                 .isDeleted(false)
                 .build();
+    }
+
+    public static ChatRoomResponseDto getChatRoomResponseDto(ChatRoom chatRoom, String nickname) {
+
+        return ChatRoomResponseDto.builder()
+                .id(chatRoom.getId())
+                .nickname(nickname)
+                .lastMessage(chatRoom.getLastMessage())
+                .lastMessageTime(chatRoom.getLastMessageTime())
+                .build();
+
     }
 
 }

--- a/src/main/java/piglin/swapswap/domain/chatroom/repository/ChatRoomQueryRepository.java
+++ b/src/main/java/piglin/swapswap/domain/chatroom/repository/ChatRoomQueryRepository.java
@@ -2,6 +2,7 @@ package piglin.swapswap.domain.chatroom.repository;
 
 import java.util.List;
 import java.util.Optional;
+import piglin.swapswap.domain.chatroom.dto.ChatRoomResponseDto;
 import piglin.swapswap.domain.chatroom.entity.ChatRoom;
 
 public interface ChatRoomQueryRepository {

--- a/src/main/java/piglin/swapswap/domain/chatroom/repository/ChatRoomQueryRepository.java
+++ b/src/main/java/piglin/swapswap/domain/chatroom/repository/ChatRoomQueryRepository.java
@@ -2,13 +2,13 @@ package piglin.swapswap.domain.chatroom.repository;
 
 import java.util.List;
 import java.util.Optional;
-import piglin.swapswap.domain.chatroom.dto.ChatRoomResponseDto;
 import piglin.swapswap.domain.chatroom.entity.ChatRoom;
 
 public interface ChatRoomQueryRepository {
 
-    List<ChatRoomResponseDto> findAllByMemberIdWithMember(Long memberId);
+    List<ChatRoom> findAllByMemberId(Long memberId);
 
-    Optional<ChatRoom> findByMyMemberIdAndOpponentMemberId(Long myMemberId, Long OpponentMemberId);
+    Optional<ChatRoom> findChatRoomByMemberIds(Long firstMemberId, Long secondMemberId);
 
 }
+

--- a/src/main/java/piglin/swapswap/domain/chatroom/repository/ChatRoomQueryRepositoryImpl.java
+++ b/src/main/java/piglin/swapswap/domain/chatroom/repository/ChatRoomQueryRepositoryImpl.java
@@ -43,8 +43,7 @@ public class ChatRoomQueryRepositoryImpl implements ChatRoomQueryRepository{
 
         return Optional.ofNullable(
                 queryFactory.selectFrom(chatRoom)
-                        .where(conditions)
-                        .where(chatRoom.isDeleted.eq(false))
+                        .where(conditions.and(chatRoom.isDeleted.eq(false)))
                         .fetchOne()
         );
     }

--- a/src/main/java/piglin/swapswap/domain/chatroom/repository/ChatRoomQueryRepositoryImpl.java
+++ b/src/main/java/piglin/swapswap/domain/chatroom/repository/ChatRoomQueryRepositoryImpl.java
@@ -1,17 +1,12 @@
 package piglin.swapswap.domain.chatroom.repository;
 
 import static piglin.swapswap.domain.chatroom.entity.QChatRoom.chatRoom;
-import static piglin.swapswap.domain.chatroom_member.entity.QChatRoomMember.chatRoomMember;
-import static piglin.swapswap.domain.member.entity.QMember.member;
 
-import com.querydsl.core.types.Projections;
-import com.querydsl.core.types.dsl.BooleanExpression;
-import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.core.BooleanBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
 import java.util.List;
 import java.util.Optional;
-import piglin.swapswap.domain.chatroom.dto.ChatRoomResponseDto;
 import piglin.swapswap.domain.chatroom.entity.ChatRoom;
 
 public class ChatRoomQueryRepositoryImpl implements ChatRoomQueryRepository{
@@ -26,50 +21,29 @@ public class ChatRoomQueryRepositoryImpl implements ChatRoomQueryRepository{
     }
 
     @Override
-    public List<ChatRoomResponseDto> findAllByMemberIdWithMember(Long memberId){
+    public List<ChatRoom> findAllByMemberId(Long memberId) {
+
         return queryFactory
-                .select(Projections.constructor(ChatRoomResponseDto.class,
-                        chatRoom.id,
-                        member.nickname,
-                        chatRoom.lastMessage,
-                        chatRoom.lastMessageTime))
-                .from(chatRoomMember)
-                .join(chatRoom).on(chatRoomMember.chatRoom.id.eq(chatRoom.id))
-                .join(member).on(chatRoomMember.member.id.eq(member.id))
-                .where(chatRoomIdIn(memberId),memberIdNotEq(memberId))
+                .selectFrom(chatRoom)
+                .where(chatRoom.firstMemberId.eq(memberId).or(chatRoom.secondMemberId.eq(memberId)))
                 .fetch();
     }
 
     @Override
-    public Optional<ChatRoom> findByMyMemberIdAndOpponentMemberId(Long memberId, Long secondMemberId) {
-        return Optional.ofNullable(queryFactory
-                .selectFrom(chatRoom)
-                .join(chatRoomMember).on(chatRoom.id.eq(chatRoomMember.chatRoom.id))
-                .where(memberIdEq(memberId), chatRoom.id.in(JPAExpressions
-                        .select(chatRoomMember.chatRoom.id)
-                                .from(chatRoomMember)
-                        .where(memberIdEq(secondMemberId))))
-                .fetchFirst()
+    public Optional<ChatRoom> findChatRoomByMemberIds(Long firstMemberId, Long secondMemberId) {
+        BooleanBuilder conditions = new BooleanBuilder();
+
+        conditions.andAnyOf(
+                chatRoom.firstMemberId.eq(firstMemberId).and(chatRoom.secondMemberId.eq(secondMemberId)),
+                chatRoom.firstMemberId.eq(secondMemberId).and(chatRoom.secondMemberId.eq(firstMemberId))
+        );
+
+        return Optional.ofNullable(
+                queryFactory.selectFrom(chatRoom)
+                        .where(conditions)
+                        .fetchOne()
         );
     }
-
-    private BooleanExpression memberIdNotEq(Long memberId) {
-
-        return member.id.ne(memberId);
-    }
-
-    private BooleanExpression memberIdEq(Long memberId) {
-
-        return chatRoomMember.member.id.eq(memberId);
-    }
-
-    private BooleanExpression chatRoomIdIn(Long memberId) {
-        return chatRoom.id.in(JPAExpressions
-                .select(chatRoomMember.chatRoom.id)
-                .from(chatRoomMember)
-                .where(memberIdEq(memberId)));
-    }
-
 
 
 }

--- a/src/main/java/piglin/swapswap/domain/chatroom/repository/ChatRoomQueryRepositoryImpl.java
+++ b/src/main/java/piglin/swapswap/domain/chatroom/repository/ChatRoomQueryRepositoryImpl.java
@@ -22,10 +22,13 @@ public class ChatRoomQueryRepositoryImpl implements ChatRoomQueryRepository{
 
     @Override
     public List<ChatRoom> findAllByMemberId(Long memberId) {
+        BooleanBuilder conditions = new BooleanBuilder();
+        conditions.and(chatRoom.firstMemberId.eq(memberId).and(chatRoom.isLeaveFirstMember.isFalse()));
+        conditions.or(chatRoom.secondMemberId.eq(memberId).and(chatRoom.isLeaveSecondMember.isFalse()));
 
         return queryFactory
                 .selectFrom(chatRoom)
-                .where(chatRoom.firstMemberId.eq(memberId).or(chatRoom.secondMemberId.eq(memberId)))
+                .where(chatRoom.firstMemberId.eq(memberId).or(chatRoom.secondMemberId.eq(memberId)).and(conditions), chatRoom.isDeleted.isFalse())
                 .fetch();
     }
 
@@ -41,9 +44,9 @@ public class ChatRoomQueryRepositoryImpl implements ChatRoomQueryRepository{
         return Optional.ofNullable(
                 queryFactory.selectFrom(chatRoom)
                         .where(conditions)
+                        .where(chatRoom.isDeleted.eq(false))
                         .fetchOne()
         );
     }
-
 
 }

--- a/src/main/java/piglin/swapswap/domain/chatroom/repository/ChatRoomQueryRepositoryImpl.java
+++ b/src/main/java/piglin/swapswap/domain/chatroom/repository/ChatRoomQueryRepositoryImpl.java
@@ -1,13 +1,17 @@
 package piglin.swapswap.domain.chatroom.repository;
 
 import static piglin.swapswap.domain.chatroom.entity.QChatRoom.chatRoom;
+import static piglin.swapswap.domain.member.entity.QMember.*;
 
 import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
 import java.util.List;
 import java.util.Optional;
+import piglin.swapswap.domain.chatroom.dto.ChatRoomResponseDto;
 import piglin.swapswap.domain.chatroom.entity.ChatRoom;
+import piglin.swapswap.domain.member.entity.QMember;
 
 public class ChatRoomQueryRepositoryImpl implements ChatRoomQueryRepository{
 
@@ -22,30 +26,34 @@ public class ChatRoomQueryRepositoryImpl implements ChatRoomQueryRepository{
 
     @Override
     public List<ChatRoom> findAllByMemberId(Long memberId) {
-        BooleanBuilder conditions = new BooleanBuilder();
-        conditions.and(chatRoom.firstMemberId.eq(memberId).and(chatRoom.isLeaveFirstMember.isFalse()));
-        conditions.or(chatRoom.secondMemberId.eq(memberId).and(chatRoom.isLeaveSecondMember.isFalse()));
 
         return queryFactory
                 .selectFrom(chatRoom)
-                .where(chatRoom.firstMemberId.eq(memberId).or(chatRoom.secondMemberId.eq(memberId)).and(conditions), chatRoom.isDeleted.isFalse())
+                .where(findChatRoomEq(memberId), chatRoom.isDeleted.isFalse())
                 .fetch();
     }
 
     @Override
     public Optional<ChatRoom> findChatRoomByMemberIds(Long firstMemberId, Long secondMemberId) {
-        BooleanBuilder conditions = new BooleanBuilder();
-
-        conditions.andAnyOf(
-                chatRoom.firstMemberId.eq(firstMemberId).and(chatRoom.secondMemberId.eq(secondMemberId)),
-                chatRoom.firstMemberId.eq(secondMemberId).and(chatRoom.secondMemberId.eq(firstMemberId))
-        );
 
         return Optional.ofNullable(
                 queryFactory.selectFrom(chatRoom)
-                        .where(conditions.and(chatRoom.isDeleted.eq(false)))
+                        .where(chatRoomFirstMemberAndSecondMemberEq(firstMemberId, secondMemberId).and(chatRoom.isDeleted.eq(false)))
                         .fetchOne()
         );
     }
 
+    private BooleanBuilder findChatRoomEq(Long memberId) {
+
+        return new BooleanBuilder().and(chatRoom.firstMemberId.eq(memberId).and(chatRoom.isLeaveFirstMember.isFalse()))
+                                   .or(chatRoom.secondMemberId.eq(memberId).and(chatRoom.isLeaveSecondMember.isFalse()));
+    }
+
+    private BooleanBuilder chatRoomFirstMemberAndSecondMemberEq(Long firstMemberId, Long secondMemberId) {
+
+        return new BooleanBuilder().andAnyOf(
+                chatRoom.firstMemberId.eq(firstMemberId).and(chatRoom.secondMemberId.eq(secondMemberId)),
+                chatRoom.firstMemberId.eq(secondMemberId).and(chatRoom.secondMemberId.eq(firstMemberId))
+        );
+    }
 }

--- a/src/main/java/piglin/swapswap/domain/chatroom/repository/ChatRoomRepository.java
+++ b/src/main/java/piglin/swapswap/domain/chatroom/repository/ChatRoomRepository.java
@@ -1,10 +1,13 @@
 package piglin.swapswap.domain.chatroom.repository;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import piglin.swapswap.domain.chatroom.entity.ChatRoom;
 
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long>, ChatRoomQueryRepository{
+
+    Optional<ChatRoom> findByIdAndIsDeletedFalse(Long roomId);
 
     void deleteAllByIsDeletedIsTrueAndModifiedTimeBefore(LocalDateTime fourteenDaysAgo);
 }

--- a/src/main/java/piglin/swapswap/domain/chatroom/service/ChatRoomService.java
+++ b/src/main/java/piglin/swapswap/domain/chatroom/service/ChatRoomService.java
@@ -17,5 +17,4 @@ public interface ChatRoomService {
     void saveMessage(MessageRequestDto requestDto);
 
     void leaveChatRoom(Member member, Long roomId);
-
 }

--- a/src/main/java/piglin/swapswap/domain/chatroom/service/ChatRoomService.java
+++ b/src/main/java/piglin/swapswap/domain/chatroom/service/ChatRoomService.java
@@ -8,6 +8,7 @@ import piglin.swapswap.domain.message.dto.response.MessageResponseDto;
 
 public interface ChatRoomService {
 
+    ChatRoomResponseDto getChatRoomResponseDto(Long roomId, Long memberId);
     List<ChatRoomResponseDto> getChatRoomList(Member member);
 
     List<MessageResponseDto> getMessageByChatRoomId(Long roomId, Member member);

--- a/src/main/java/piglin/swapswap/domain/chatroom/service/ChatRoomService.java
+++ b/src/main/java/piglin/swapswap/domain/chatroom/service/ChatRoomService.java
@@ -9,6 +9,7 @@ import piglin.swapswap.domain.message.dto.response.MessageResponseDto;
 public interface ChatRoomService {
 
     ChatRoomResponseDto getChatRoomResponseDto(Long roomId, Long memberId);
+
     List<ChatRoomResponseDto> getChatRoomList(Member member);
 
     List<MessageResponseDto> getMessageByChatRoomId(Long roomId, Member member);

--- a/src/main/java/piglin/swapswap/domain/chatroom/service/ChatRoomServiceImpl.java
+++ b/src/main/java/piglin/swapswap/domain/chatroom/service/ChatRoomServiceImpl.java
@@ -1,6 +1,7 @@
 package piglin.swapswap.domain.chatroom.service;
 
 import jakarta.transaction.Transactional;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -129,20 +130,23 @@ public class ChatRoomServiceImpl implements ChatRoomService {
 
         Map<Long, String> otherMemberIdToNicknameMap = otherMembers.stream().collect(Collectors.toMap(Member::getId, Member::getNickname));
 
-        return chatRoomList.stream().map(chatRoom -> {
+        return chatRoomList.stream()
 
-            Long otherMemberId = getOtherMemberId(chatRoom, memberId);
-            String otherMemberNickname = otherMemberIdToNicknameMap.get(otherMemberId);
+                .sorted(Comparator.comparing(ChatRoom::getLastMessageTime).reversed()) // 내림차순 정렬
+                .map(chatRoom -> {
+                    Long otherMemberId = getOtherMemberId(chatRoom, memberId);
+                    String otherMemberNickname = otherMemberIdToNicknameMap.get(otherMemberId);
 
-            return ChatRoomResponseDto.builder()
-                    .id(chatRoom.getId())
-                    .nickname(otherMemberNickname)
-                    .lastMessage(chatRoom.getLastMessage())
-                    .lastMessageTime(chatRoom.getLastMessageTime())
-                    .build();
-
-        }).toList();
+                    return ChatRoomResponseDto.builder()
+                            .id(chatRoom.getId())
+                            .nickname(otherMemberNickname)
+                            .lastMessage(chatRoom.getLastMessage())
+                            .lastMessageTime(chatRoom.getLastMessageTime())
+                            .build();
+                })
+                .toList();
     }
+
 
     private Long getOtherMemberId(ChatRoom chatRoom, Long memberId) {
         if (chatRoom.getFirstMemberId().equals(memberId)) {

--- a/src/main/java/piglin/swapswap/domain/member/repository/MemberRepository.java
+++ b/src/main/java/piglin/swapswap/domain/member/repository/MemberRepository.java
@@ -22,4 +22,6 @@ public interface MemberRepository extends JpaRepository<Member, Long>, MemberQue
     boolean existsByIdAndIsDeletedIsFalse(Long memberId);
 
     boolean existsByNickname(String nickname);
+
+    List<Member> findByIdIn(List<Long> memberIds);
 }

--- a/src/main/java/piglin/swapswap/domain/member/service/MemberService.java
+++ b/src/main/java/piglin/swapswap/domain/member/service/MemberService.java
@@ -1,5 +1,6 @@
 package piglin.swapswap.domain.member.service;
 
+import java.util.List;
 import piglin.swapswap.domain.member.dto.MemberNicknameDto;
 import piglin.swapswap.domain.member.entity.Member;
 
@@ -16,4 +17,6 @@ public interface MemberService {
     Member getMember(Long memberId);
 
     boolean checkNicknameExists(String nickname);
+
+    List<Member> getMembers(List<Long> memberIds);
 }

--- a/src/main/java/piglin/swapswap/domain/member/service/MemberServiceImplV1.java
+++ b/src/main/java/piglin/swapswap/domain/member/service/MemberServiceImplV1.java
@@ -96,4 +96,9 @@ public class MemberServiceImplV1 implements MemberService {
     public boolean checkNicknameExists(String nickname) {
         return memberRepository.existsByNickname(nickname);
     }
+
+    @Override
+    public List<Member> getMembers(List<Long> memberIds) {
+        return memberRepository.findByIdIn(memberIds);
+    }
 }

--- a/src/main/java/piglin/swapswap/domain/message/dto/request/MessageRequestDto.java
+++ b/src/main/java/piglin/swapswap/domain/message/dto/request/MessageRequestDto.java
@@ -7,10 +7,11 @@ import piglin.swapswap.domain.message.constant.MessageType;
 
 @Builder
 public record MessageRequestDto (
+        Long chatRoomId,
+        Long senderId,
         MessageType type,
-        String senderNickname,
-        String text,
-        Long chatRoomId
+        String text
 ) {
 
 }
+

--- a/src/main/java/piglin/swapswap/domain/message/dto/response/MessageResponseDto.java
+++ b/src/main/java/piglin/swapswap/domain/message/dto/response/MessageResponseDto.java
@@ -8,11 +8,9 @@ import piglin.swapswap.domain.message.constant.MessageType;
 
 @Builder
 public record MessageResponseDto (
-        Long id,
+        Long senderId,
         MessageType type,
-        String senderNickname,
         String text,
-        Long chatRoomId,
         LocalDateTime createdTime
 ) {
 

--- a/src/main/java/piglin/swapswap/domain/message/entity/Message.java
+++ b/src/main/java/piglin/swapswap/domain/message/entity/Message.java
@@ -14,7 +14,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import piglin.swapswap.domain.chatroom.entity.ChatRoom;
 import piglin.swapswap.domain.common.BaseTime;
 import piglin.swapswap.domain.message.constant.MessageType;
@@ -30,11 +29,11 @@ public class Message extends BaseTime {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(nullable = false)
+    private Long memberId;
+
     @Enumerated(EnumType.STRING)
     private MessageType type;
-
-    @Column(nullable = false)
-    private String senderNickname;
 
     @Column(nullable = false)
     private String text;

--- a/src/main/java/piglin/swapswap/domain/message/mapper/MessageMapper.java
+++ b/src/main/java/piglin/swapswap/domain/message/mapper/MessageMapper.java
@@ -3,6 +3,7 @@ package piglin.swapswap.domain.message.mapper;
 import java.util.List;
 import piglin.swapswap.domain.chatroom.entity.ChatRoom;
 import piglin.swapswap.domain.member.entity.Member;
+import piglin.swapswap.domain.message.constant.MessageType;
 import piglin.swapswap.domain.message.dto.request.MessageRequestDto;
 import piglin.swapswap.domain.message.dto.response.MessageResponseDto;
 import piglin.swapswap.domain.message.entity.Message;
@@ -18,6 +19,17 @@ public class MessageMapper {
                 .isDeleted(false)
                 .chatRoom(chatRoom)
                 .build();
+    }
+
+    public static MessageRequestDto createMessageRequestDto(Long roomId, Long senderId, MessageType type, String text) {
+
+        return MessageRequestDto.builder()
+                .chatRoomId(roomId)
+                .senderId(senderId)
+                .type(type)
+                .text(text)
+                .build();
+
     }
 
     public static MessageResponseDto messageToDto(Message message) {

--- a/src/main/java/piglin/swapswap/domain/message/mapper/MessageMapper.java
+++ b/src/main/java/piglin/swapswap/domain/message/mapper/MessageMapper.java
@@ -2,17 +2,18 @@ package piglin.swapswap.domain.message.mapper;
 
 import java.util.List;
 import piglin.swapswap.domain.chatroom.entity.ChatRoom;
+import piglin.swapswap.domain.member.entity.Member;
 import piglin.swapswap.domain.message.dto.request.MessageRequestDto;
 import piglin.swapswap.domain.message.dto.response.MessageResponseDto;
 import piglin.swapswap.domain.message.entity.Message;
 
 public class MessageMapper {
 
-    public static Message createMessage(MessageRequestDto messageDto, ChatRoom chatRoom) {
+    public static Message createMessage(Member member, ChatRoom chatRoom, MessageRequestDto messageDto) {
 
         return Message.builder()
+                .memberId(member.getId())
                 .type(messageDto.type())
-                .senderNickname(messageDto.senderNickname())
                 .text(messageDto.text())
                 .isDeleted(false)
                 .chatRoom(chatRoom)
@@ -22,11 +23,9 @@ public class MessageMapper {
     public static MessageResponseDto messageToDto(Message message) {
 
         return MessageResponseDto.builder()
-                .id(message.getId())
+                .senderId(message.getMemberId())
                 .type(message.getType())
-                .senderNickname(message.getSenderNickname())
                 .text(message.getText())
-                .chatRoomId(message.getChatRoom().getId())
                 .createdTime(message.getCreatedTime())
                 .build();
     }
@@ -37,3 +36,4 @@ public class MessageMapper {
     }
 
 }
+

--- a/src/main/java/piglin/swapswap/domain/message/repository/MessageQueryRepository.java
+++ b/src/main/java/piglin/swapswap/domain/message/repository/MessageQueryRepository.java
@@ -4,6 +4,6 @@ import piglin.swapswap.domain.chatroom.entity.ChatRoom;
 
 public interface MessageQueryRepository {
 
-    void deleteMessage(ChatRoom chatRoom);
+    void deleteAllChatRoomMessage(ChatRoom chatRoom);
 }
 

--- a/src/main/java/piglin/swapswap/domain/message/repository/MessageQueryRepositoryImpl.java
+++ b/src/main/java/piglin/swapswap/domain/message/repository/MessageQueryRepositoryImpl.java
@@ -19,7 +19,7 @@ public class MessageQueryRepositoryImpl implements MessageQueryRepository {
     }
 
     @Override
-    public void deleteMessage(ChatRoom chatRoom) {
+    public void deleteAllChatRoomMessage(ChatRoom chatRoom) {
 
         queryFactory.update(message)
                 .set(message.isDeleted, true)

--- a/src/main/java/piglin/swapswap/domain/message/repository/MessageRepository.java
+++ b/src/main/java/piglin/swapswap/domain/message/repository/MessageRepository.java
@@ -6,5 +6,5 @@ import piglin.swapswap.domain.message.entity.Message;
 
 public interface MessageRepository extends JpaRepository<Message, Long>, MessageQueryRepository {
 
-    List<Message> findAllByChatRoom_Id(Long roomId);
+    List<Message> findAllByChatRoomId(Long roomId);
 }

--- a/src/main/java/piglin/swapswap/domain/message/repository/MessageRepository.java
+++ b/src/main/java/piglin/swapswap/domain/message/repository/MessageRepository.java
@@ -2,7 +2,6 @@ package piglin.swapswap.domain.message.repository;
 
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
-import piglin.swapswap.domain.chatroom.entity.ChatRoom;
 import piglin.swapswap.domain.message.entity.Message;
 
 public interface MessageRepository extends JpaRepository<Message, Long>, MessageQueryRepository {

--- a/src/main/java/piglin/swapswap/domain/message/service/MessageServiceImpl.java
+++ b/src/main/java/piglin/swapswap/domain/message/service/MessageServiceImpl.java
@@ -16,7 +16,7 @@ public class MessageServiceImpl implements MessageService {
     @Override
     public List<Message> findAllByChatRoomId(Long roomId) {
 
-        return messageRepository.findAllByChatRoom_Id(roomId);
+        return messageRepository.findAllByChatRoomId(roomId);
     }
 
     @Override
@@ -28,6 +28,6 @@ public class MessageServiceImpl implements MessageService {
     @Override
     public void deleteMessage(ChatRoom chatRoom) {
 
-        messageRepository.deleteMessage(chatRoom);
+        messageRepository.deleteAllChatRoomMessage(chatRoom);
     }
 }

--- a/src/main/java/piglin/swapswap/global/security/UserDetailsImpl.java
+++ b/src/main/java/piglin/swapswap/global/security/UserDetailsImpl.java
@@ -36,6 +36,10 @@ public class UserDetailsImpl implements UserDetails {
         return this.member;
     }
 
+    public Long getMemberId() {
+        return member.getId();
+    }
+
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
         MemberRole role = member.getRole();

--- a/src/main/resources/templates/chat/chatroom.html
+++ b/src/main/resources/templates/chat/chatroom.html
@@ -7,124 +7,118 @@
 </head>
 <body>
 <div layout:fragment="content">
-<section class="section--chat">
-  <div class="inner">
-    <div class="header">채팅</div>
-    <div id="chatContainer" class="chat-container">
-      <div id="chatRoomId" th:text="${roomId}" style="display: none;"></div>
-      <div id="currentUserId" style="display: none;" th:text="${#authentication.principal.nickname}"></div>
-      <div class="connecting">
-        Connecting...
-      </div>
-
-      <div th:each="message : ${messageList}" th:class="${message.senderNickname == #authentication.principal.nickname} ? 'chat ch2' : 'chat ch1'">
-        <div class="sender" th:if="${message.senderNickname != #authentication.principal.nickname}" th:text="${message.senderNickname}"></div>
-        <div class="textbox" th:text="${message.text}"></div>
-      </div>
-
-    </div>
-    <form id="messageForm" name="messageForm" nameForm="messageForm">
-      <div class="form-group">
-        <div class="input-group clearfix">
-          <input type="text" id="message" placeholder="Type a message..." autocomplete="off" class="form-control"/>
-          <button type="submit" >보내기</button>
-          <button class="leave" th:data-room-id="${roomId}" th:onclick="leaveChatRoom(this.getAttribute('data-room-id'))">채팅방 나가기</button>
+  <section class="section--chat">
+    <div class="inner">
+      <div class="header" th:text="${nickname}"></div>
+      <div id="chatContainer" class="chat-container">
+        <div id="chatRoomId" th:text="${roomId}" style="display: none;"></div>
+        <div id="currentMemberId" style="display: none;" th:text="${#authentication.principal.memberId}"></div>
+        <div class="connecting">
+          Connecting...
         </div>
+
+        <div th:each="message : ${messageList}" th:class="${message.senderId == #authentication.principal.memberId} ? 'chat ch2' : 'chat ch1'">
+          <div class="textbox" th:text="${message.text}"></div>
+        </div>
+
       </div>
-    </form>
-  </div>
-</section>
+      <form id="messageForm" name="messageForm" nameForm="messageForm">
+        <div class="form-group">
+          <div class="input-group clearfix">
+            <input type="text" id="message" placeholder="Type a message..." autocomplete="off" class="form-control"/>
+            <button type="submit" >보내기</button>
+            <button class="leave" th:data-room-id="${roomId}" th:onclick="leaveChatRoom(this.getAttribute('data-room-id'))">채팅방 나가기</button>
+          </div>
+        </div>
+      </form>
+    </div>
+  </section>
 
-<script src="https://cdnjs.cloudflare.com/ajax/libs/sockjs-client/1.1.4/sockjs.min.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/stomp.js/2.3.3/stomp.min.js"></script>
-<script src="https://code.jquery.com/jquery-3.6.4.min.js"></script>
-<script th:inline="javascript">
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/sockjs-client/1.1.4/sockjs.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/stomp.js/2.3.3/stomp.min.js"></script>
+  <script src="https://code.jquery.com/jquery-3.6.4.min.js"></script>
+  <script th:inline="javascript">
 
-  const chatRoomId = [[${roomId}]];
-  const messageForm = document.querySelector('#messageForm');
-  const messageInput = document.querySelector('#message');
-  const connectingElement = document.querySelector('.connecting');
-  const currentUserIdElement = document.getElementById('currentUserId');
-  const senderNickname = currentUserIdElement.textContent;
-  const chatContainer = document.getElementById('chatContainer');
-  let stompClient = null;
+    const chatRoomId = [[${roomId}]];
+    const messageForm = document.querySelector('#messageForm');
+    const messageInput = document.querySelector('#message');
+    const connectingElement = document.querySelector('.connecting');
+    const currentMemberId = document.getElementById('currentMemberId');
+    const senderId = currentMemberId.textContent;
+    const chatContainer = document.getElementById('chatContainer');
+    let stompClient = null;
 
-  window.onload = function connect() {
-    let socket = new SockJS('/ws/chat')
-    stompClient = Stomp.over(socket);
+    window.onload = function connect() {
+      let socket = new SockJS('/ws/chat')
+      stompClient = Stomp.over(socket);
 
-    stompClient.connect({}, onConnected, onError);
-  }
-
-  function onConnected() {
-    stompClient.subscribe('/queue/chat/room' + chatRoomId, onMessageReceived);
-    connectingElement.parentNode.removeChild(connectingElement);
-
-    chatContainer.scrollTop = chatContainer.scrollHeight;
-  }
-
-  function onError(error) {
-    connectingElement.textContent = 'Could not connect to WebSocket server. Please refresh this page to try again!';
-    connectingElement.style.color = 'red';
-  }
-
-  function sendMessage(event) {
-    let messageContent = messageInput.value.trim();
-
-    if (messageContent && stompClient) {
-      let chatMessage = {
-        chatRoomId: chatRoomId,
-        senderNickname: senderNickname,
-        text: messageInput.value,
-        type: 'CHAT'
-      };
-
-      stompClient.send('/app/chat/message', {}, JSON.stringify(chatMessage));
-      messageInput.value = '';
-      messageInput.focus();
-    }
-    event.preventDefault();
-  }
-
-  function onMessageReceived(payload) {
-    let message = JSON.parse(payload.body);
-    let messageElement = document.createElement('div');
-
-    let senderDiv = document.createElement('div');
-    senderDiv.textContent = message.senderNickname;
-    let textBoxDiv = document.createElement('div');
-    textBoxDiv.textContent = message.text;
-
-    messageElement.classList.add('chat');
-    senderDiv.classList.add('sender');
-    textBoxDiv.classList.add('textbox');
-
-    if (message.senderNickname === senderNickname) {
-      messageElement.classList.add('ch2');
-      senderDiv.style.display = 'none';
-    } else {
-      messageElement.classList.add('ch1');
+      stompClient.connect({}, onConnected, onError);
     }
 
-    messageElement.appendChild(senderDiv);
-    messageElement.appendChild(textBoxDiv);
-    chatContainer.appendChild(messageElement);
-    chatContainer.scrollTop = chatContainer.scrollHeight;
-  }
-  function leaveChatRoom(roomId) {
-    $.ajax({
-      url: '/chats/leave',
-      type: 'DELETE',
-      data: { roomId : roomId },
+    function onConnected() {
+      stompClient.subscribe('/queue/chat/room' + chatRoomId, onMessageReceived);
+      connectingElement.parentNode.removeChild(connectingElement);
 
-      success: function () {
-        window.location.href = '/chats'
+      chatContainer.scrollTop = chatContainer.scrollHeight;
+    }
+
+    function onError(error) {
+      connectingElement.textContent = 'Could not connect to WebSocket server. Please refresh this page to try again!';
+      connectingElement.style.color = 'red';
+    }
+
+    function sendMessage(event) {
+      let messageContent = messageInput.value.trim();
+
+      if (messageContent && stompClient) {
+        let chatMessage = {
+          chatRoomId: chatRoomId,
+          type: 'CHAT',
+          senderId: senderId,
+          text: messageInput.value
+        };
+
+        stompClient.send('/app/chat/message', {}, JSON.stringify(chatMessage));
+        messageInput.value = '';
+        messageInput.focus();
       }
-    })
-  }
+      event.preventDefault();
+    }
 
-  messageForm.addEventListener('submit', sendMessage, true);
-</script>
+    function onMessageReceived(payload) {
+      let message = JSON.parse(payload.body);
+      let messageElement = document.createElement('div');
+
+      let textBoxDiv = document.createElement('div');
+      textBoxDiv.textContent = message.text;
+
+      messageElement.classList.add('chat');
+      textBoxDiv.classList.add('textbox');
+
+      if (message.senderId.toString() === senderId.toString()) {
+        messageElement.classList.add('ch2');
+      } else {
+        messageElement.classList.add('ch1');
+      }
+
+      messageElement.appendChild(textBoxDiv);
+      chatContainer.appendChild(messageElement);
+      chatContainer.scrollTop = chatContainer.scrollHeight;
+    }
+    function leaveChatRoom(roomId) {
+      $.ajax({
+        url: '/chats/leave',
+        type: 'DELETE',
+        data: { roomId : roomId },
+
+        success: function () {
+          window.location.href = '/chats'
+        }
+      })
+    }
+
+    messageForm.addEventListener('submit', sendMessage, true);
+  </script>
 </div>
 </body>
 </html>

--- a/src/main/resources/templates/chat/chatroom.html
+++ b/src/main/resources/templates/chat/chatroom.html
@@ -9,7 +9,7 @@
 <div layout:fragment="content">
   <section class="section--chat">
     <div class="inner">
-      <div class="header" th:text="${nickname}"></div>
+      <div class="header" th:text="${chatRoom.nickname}"></div>
       <div id="chatContainer" class="chat-container">
         <div id="chatRoomId" th:text="${roomId}" style="display: none;"></div>
         <div id="currentMemberId" style="display: none;" th:text="${#authentication.principal.memberId}"></div>

--- a/src/main/resources/templates/chat/chatroomList.html
+++ b/src/main/resources/templates/chat/chatroomList.html
@@ -15,11 +15,9 @@
           <p>현재 대화 중인 채팅방이 없습니다.</p>
         </div>
 
-        <a th:each="chatRoom : ${chatRoomList}" th:href="@{/chats/room/{roomId}(roomId=${chatRoom.id}, nickname=${chatRoom.nickname})}" class="room">
+        <a th:each="chatRoom : ${chatRoomList}" th:href="@{/chats/room/{roomId}(roomId=${chatRoom.id})}" class="room">
 
-          <div class="other-username" th:text="${chatRoom.nickname + '님과의 채팅방'}">
-            <span>와의 채팅방</span>
-          </div>
+          <div class="other-username" th:text="${chatRoom.nickname + '님과의 채팅방'}"></div>
 
           <div class="lastChatMessage" th:text="${chatRoom.lastMessage}"></div>
           <div class="modifiedAt">

--- a/src/main/resources/templates/chat/chatroomList.html
+++ b/src/main/resources/templates/chat/chatroomList.html
@@ -5,27 +5,34 @@
 
 <body>
 <div layout:fragment="content">
-<section class="section--message">
-  <div class="inner">
-    <div class="header">채팅방 목록</div>
-    <div class="room-container">
+  <section class="section--message">
+    <div class="inner">
+      <div class="header">채팅방 목록</div>
+      <div class="room-container">
 
-      <a th:each="chatRoom : ${chatRoomList}" th:href="@{/chats/room/{roomId}(roomId=${chatRoom.id})}" class="room">
-        <div class="other-username" th:text="${chatRoom.username} + '님과의 채팅방'">
-          <span>와의 채팅방</span>
+
+        <div class="room-container" th:if="${#lists.isEmpty(chatRoomList)}">
+          <p>현재 대화 중인 채팅방이 없습니다.</p>
         </div>
-        <div class="lastChatMessage" th:text="${chatRoom.lastMessage}"></div>
-        <div class="modifiedAt">
+
+        <a th:each="chatRoom : ${chatRoomList}" th:href="@{/chats/room/{roomId}(roomId=${chatRoom.id}, nickname=${chatRoom.nickname})}" class="room">
+
+          <div class="other-username" th:text="${chatRoom.nickname + '님과의 채팅방'}">
+            <span>와의 채팅방</span>
+          </div>
+
+          <div class="lastChatMessage" th:text="${chatRoom.lastMessage}"></div>
+          <div class="modifiedAt">
           <span th:if="${#temporals.format(chatRoom.lastMessageTime, 'yyyyMMdd') == #temporals.format(#temporals.createNow(), 'yyyyMMdd')}"
                 th:text="${#temporals.format(chatRoom.lastMessageTime, 'HH:mm')}">Today</span>
-          <span th:unless="${#temporals.format(chatRoom.lastMessageTime, 'yyyyMMdd') == #temporals.format(#temporals.createNow(), 'yyyyMMdd')}"
-                th:text="${#temporals.format(chatRoom.lastMessageTime, 'yyyy-MM-dd')}"></span>
-        </div>
-      </a>
+            <span th:unless="${#temporals.format(chatRoom.lastMessageTime, 'yyyyMMdd') == #temporals.format(#temporals.createNow(), 'yyyyMMdd')}"
+                  th:text="${#temporals.format(chatRoom.lastMessageTime, 'yyyy-MM-dd')}"></span>
+          </div>
+        </a>
 
+      </div>
     </div>
-  </div>
-</section>
+  </section>
 </div>
 </body>
 </html>

--- a/src/main/resources/templates/member/login.html
+++ b/src/main/resources/templates/member/login.html
@@ -17,7 +17,7 @@
         로그인
       </h2>
       <div class="actions">
-        <a href="https://kauth.kakao.com/oauth/authorize?client_id=a304535271497a06332e50e9eec191ab&redirect_uri=http://swapswap.shop/login/kakao/callback&response_type=code">
+        <a href="https://kauth.kakao.com/oauth/authorize?client_id=a304535271497a06332e50e9eec191ab&redirect_uri=http://localhost:8080/login/kakao/callback&response_type=code">
           <img src="/images/kakaologinlogo.png" alt="Kakao Logo">
           <p>카카오로 간편 로그인</p>
         </a>

--- a/src/main/resources/templates/member/login.html
+++ b/src/main/resources/templates/member/login.html
@@ -17,7 +17,7 @@
         로그인
       </h2>
       <div class="actions">
-        <a href="https://kauth.kakao.com/oauth/authorize?client_id=a304535271497a06332e50e9eec191ab&redirect_uri=http://localhost:8080/login/kakao/callback&response_type=code">
+        <a href="https://kauth.kakao.com/oauth/authorize?client_id=a304535271497a06332e50e9eec191ab&redirect_uri=http://swapswap.shop/login/kakao/callback&response_type=code">
           <img src="/images/kakaologinlogo.png" alt="Kakao Logo">
           <p>카카오로 간편 로그인</p>
         </a>

--- a/src/main/resources/templates/post/post.html
+++ b/src/main/resources/templates/post/post.html
@@ -142,6 +142,7 @@
   <script th:inline="javascript">
 
     const isMemberLogged = [[${isMemberLogged}]];
+    const postAuthor = [[${postGetResponseDto.author}]];
 
     function toggleFavorite(postId) {
 
@@ -201,11 +202,10 @@
 
         success: function (response) {
           console.log(response);
-          window.location.href = '/chats/room/' + response;
+          window.location.href = '/chats/room/' + response + '?nickname=' + postAuthor;
         },
       });
     }
-
 
   </script>
 </div>

--- a/src/main/resources/templates/post/post.html
+++ b/src/main/resources/templates/post/post.html
@@ -46,8 +46,7 @@
           </div>
           <div class="post-request-button"
                sec:authorize="isAuthenticated()"
-               th:if="${postGetResponseDto.dealStatus == postGetResponseDto.dealStatus.REQUESTED} and ${!isWriter}"
-          >
+               th:if="${postGetResponseDto.dealStatus == postGetResponseDto.dealStatus.REQUESTED} and ${!isWriter}">
             <a th:href="@{/deals/request(secondMemberId=${postGetResponseDto.memberId},memberName=${postGetResponseDto.author})}">
               요청하기
             </a>
@@ -142,7 +141,6 @@
   <script th:inline="javascript">
 
     const isMemberLogged = [[${isMemberLogged}]];
-    const postAuthor = [[${postGetResponseDto.author}]];
 
     function toggleFavorite(postId) {
 
@@ -202,7 +200,7 @@
 
         success: function (response) {
           console.log(response);
-          window.location.href = '/chats/room/' + response + '?nickname=' + postAuthor;
+          window.location.href = '/chats/room/' + response;
         },
       });
     }


### PR DESCRIPTION
## 📝 개요
- 엔티티간에 연관관계를 가지지 않는 방향으로 재설계 하였습니다.
- ChatRoomMember 클래스는 더 이상 사용하지 않습니다.
<br>

## 👨‍💻 작업 내용
- ChatRoom과 Message가 Member와 갖고 있던 연관관계를 제거하고 String 값이나 Long 값으로 id, nickname 값을 가지고 있도록 하였습니다.
- 채팅방 목록을 가져오는 메소드를 QueryDSL을 사용하여 작성하였지만 제대로 작동하지 않아 기존과 다르게 작성하였습니다.
- ChatRoomMember 클래스는 더 이상 사용하지 않습니다만 아직 삭제하지는 않았습니다.
- UserDetailsImpl에 회원의 id를 반환 받는 메소드를 작성하였습니다.

- 추가
- ChatRoom 엔티티에 isLeaveFirstMember, isLeaveSecondMember 필드를 추가해서 채팅방에서 회원이 나갈 시 null 값으로 만들지 않고 해당 필드를 true로 바꾸어 채팅방을 나간 후에도 해당 채팅방에 참여한 회원을 알 수 있도록 하였습니다.
- RequestParam으로 값을 받고 있던 부분을 제거하였습니다.
<img width="629" alt="image" src="https://github.com/Team-Piglin/swapswap/assets/120175285/9f8d60f8-8d99-4edc-acf9-b7d7db72795d">

<br>

## 🙇🏻‍♂️ 리뷰어에게
- ChatRoomServierImpl.class에 getChatRoomResponseDtoList 메소드가 채팅방 목록을 가져오는 메소드 입니다.
- 좋은 코드인 것 같지는 않아서 더 좋은 방법이 있다면 알려주시면 감사하겠습니다. 
<br>
