### PR TITLE
feat: post city 검색 바로 적용되게 수정 / Province 오타 수정

### DIFF
--- a/src/main/java/piglin/swapswap/domain/post/constant/Province.java
+++ b/src/main/java/piglin/swapswap/domain/post/constant/Province.java
@@ -9,7 +9,7 @@ public enum Province {
     SOUTH_CHUNGCHEONG("충청남도"),
     NORTH_GYEONGSANG("경상북도"),
     SOUTH_GYEONGSANG("경상남도"),
-    NORTH_CHUNGCHEONG("충청남도"),
+    NORTH_CHUNGCHEONG("충청북도"),
     GANGWON("강원도"),
     NORTH_JEOLLA("전라북도"),
     JEJU("제주도"),

--- a/src/main/resources/templates/common/fragments/nav.html
+++ b/src/main/resources/templates/common/fragments/nav.html
@@ -216,6 +216,7 @@
 
     navCityInput.addEventListener('change', function() {
       localStorage.setItem('selectedCity', this.value);
+      updateSearch();
     });
 
     const rainbowColors = ['red', 'orange', 'green', 'blue', 'indigo', 'violet'];


### PR DESCRIPTION
## 📝 개요
- [#229 ] 에 관한 내용입니다.
<br>

## 👨‍💻 작업 내용
- post city 검색 바로 적용되게 수정 / Province 오타 수정
<br>

## 🙇🏻‍♂️ 리뷰어에게
- 코드는 정말 별거 없는데,,, 그 이유가 js로 도, 도시 나눠놓고 경기도 선택하면 경기도 도시들 쫙 나오면서 도시 선택하고 기존 처럼 검색 되게 끔 하려고 했는데 적용이 계속 안되더라구요,, 하나하면 하나 이상해지고,, 이상적으로 작동이 안됩니다. 그래서 코드 3번 갈아 엎었었는데 프론트에서 로컬 스토리지 사용하고 이런 부분들이 꽤나 어려워서 포기하고 다른 부분에 집중하려고 우선 UT 개선 사항 올립니다..
- 쓱 봐주세요 ㅠ
<br>
