### PR TITLE
test: 게시글 삭제 테스트 추가

### DIFF
--- a/src/test/java/piglin/swapswap/domain/post/service/PostServiceImplV1UnitTest.java
+++ b/src/test/java/piglin/swapswap/domain/post/service/PostServiceImplV1UnitTest.java
@@ -22,6 +22,7 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.web.multipart.MultipartFile;
+import piglin.swapswap.domain.favorite.service.FavoriteServiceImplV1;
 import piglin.swapswap.domain.member.entity.Member;
 import piglin.swapswap.domain.post.constant.Category;
 import piglin.swapswap.domain.post.constant.City;
@@ -43,6 +44,9 @@ class PostServiceImplV1UnitTest {
 
     @Mock
     private PostRepository postRepository;
+
+    @Mock
+    private FavoriteServiceImplV1 favoriteService;
 
     @InjectMocks
     private PostServiceImplV1 postService;
@@ -329,6 +333,55 @@ class PostServiceImplV1UnitTest {
             when(postRepository.findByIdAndIsDeletedIsFalse(postId)).thenReturn(Optional.of(post));
             // When - Then
             assertThatThrownBy(() -> postService.updatePost(postId, anotherMember, requestDto))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessageContaining(ErrorCode.REJECT_MODIFIYING_POST_EXCEPTION.getMessage());
+        }
+    }
+
+    @Nested
+    @DisplayName("게시글 삭제 테스트 모음")
+    class DeletePostTestList {
+
+        @Mock
+        private Post post;
+
+        @Test
+        @DisplayName("게시글 삭제 - 성공")
+        void deletePost_success() {
+            // Given
+            post = Post.builder().id(1L).member(member).isDeleted(false).build();
+            when(postRepository.findByIdAndIsDeletedIsFalse(memberId)).thenReturn(Optional.of(post));
+
+            // When
+            postService.deletePost(member, post.getId());
+
+            // Then
+            assertThat(post.getIsDeleted()).isTrue();
+        }
+
+        @Test
+        @DisplayName("게시글 삭제 - 실패 / 게시글이 이미 지워진 상태입니다.")
+        void deletePost_Fail_PostAlreadyDeleted() {
+            // Given
+            post = Post.builder().id(1L).member(member).isDeleted(true).build();
+            when(postRepository.findByIdAndIsDeletedIsFalse(memberId)).thenReturn(Optional.of(post));
+
+            // When - Then
+            assertThatThrownBy(() -> postService.deletePost(member, post.getId()))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessageContaining(ErrorCode.POST_ALREADY_DELETED.getMessage());
+        }
+
+        @Test
+        @DisplayName("게시글 삭제 - 실패 / 작성자만 수정 할 수 있습니다.")
+        void deletePost_Fail_PostWriterNotMatched() {
+            // Given
+            Member anotherMember = Member.builder().id(2L).build();
+            post = Post.builder().id(1L).member(member).isDeleted(true).build();
+            when(postRepository.findByIdAndIsDeletedIsFalse(post.getId())).thenReturn(Optional.of(post));
+
+            // When - Then
+            assertThatThrownBy(() -> postService.deletePost(anotherMember, post.getId()))
                     .isInstanceOf(BusinessException.class)
                     .hasMessageContaining(ErrorCode.REJECT_MODIFIYING_POST_EXCEPTION.getMessage());
         }


### PR DESCRIPTION
## 📝 개요
- deletePost 메서드에 대한 테스트 코드가 없었습니다.
<br>

## 👨‍💻 작업 내용
- 게시글 삭제 테스트 코드 추가했습니다.
<br>

## 🙇🏻‍♂️ 리뷰어에게
- 스케줄러 테스트 코드도 추가하려 했는데, 현재 게시글 완전 삭제되는 로직은 다른 방식으로 바뀔 예정이라 추가하지 않았습니다.
<br>
