### PR TITLE
feat: Log HttpRequestLog / SwapLog 분리

### DIFF
--- a/src/main/java/piglin/swapswap/domain/coupon/controller/CouponController.java
+++ b/src/main/java/piglin/swapswap/domain/coupon/controller/CouponController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 import piglin.swapswap.domain.coupon.service.CouponService;
 import piglin.swapswap.domain.member.entity.Member;
 import piglin.swapswap.global.annotation.AuthMember;
+import piglin.swapswap.global.annotation.HttpRequestLog;
 
 @Controller
 @RequiredArgsConstructor
@@ -32,6 +33,7 @@ public class CouponController {
     }
 
     @ResponseBody
+    @HttpRequestLog
     @PostMapping("/event")
     public ResponseEntity<?> issueEventCoupon(@AuthMember Member member) {
 

--- a/src/main/java/piglin/swapswap/domain/member/contorller/MemberController.java
+++ b/src/main/java/piglin/swapswap/domain/member/contorller/MemberController.java
@@ -24,6 +24,7 @@ import piglin.swapswap.domain.membercoupon.service.MemberCouponService;
 import piglin.swapswap.domain.post.dto.response.PostListResponseDto;
 import piglin.swapswap.domain.post.service.PostService;
 import piglin.swapswap.global.annotation.AuthMember;
+import piglin.swapswap.global.annotation.HttpRequestLog;
 import piglin.swapswap.global.jwt.JwtCookieManager;
 
 @Slf4j
@@ -39,6 +40,7 @@ public class MemberController {
 
     private final MemberCouponService memberCouponService;
 
+    @HttpRequestLog
     @GetMapping("/login/kakao/callback")
     public String kakaoLogin(
             @RequestParam String code,
@@ -65,6 +67,7 @@ public class MemberController {
         return "redirect:/";
     }
 
+    @HttpRequestLog
     @ResponseBody
     @PatchMapping("/members/nickname")
     public ResponseEntity<?> updateNickname(
@@ -97,6 +100,7 @@ public class MemberController {
         return "member/unregister";
     }
 
+    @HttpRequestLog
     @ResponseBody
     @DeleteMapping("/members")
     public ResponseEntity<?> unregister(

--- a/src/main/java/piglin/swapswap/domain/post/controller/PostController.java
+++ b/src/main/java/piglin/swapswap/domain/post/controller/PostController.java
@@ -24,6 +24,7 @@ import piglin.swapswap.domain.post.dto.response.PostGetResponseDto;
 import piglin.swapswap.domain.post.dto.response.PostSimpleResponseDto;
 import piglin.swapswap.domain.post.service.PostService;
 import piglin.swapswap.global.annotation.AuthMember;
+import piglin.swapswap.global.annotation.HttpRequestLog;
 
 @Controller
 @RequiredArgsConstructor
@@ -31,6 +32,7 @@ public class PostController {
 
     private final PostService postService;
 
+    @HttpRequestLog
     @PostMapping("/posts/write")
     public String createPost(
             @Valid @ModelAttribute PostCreateRequestDto requestDto,
@@ -117,6 +119,7 @@ public class PostController {
         return ResponseEntity.ok().build();
     }
 
+    @HttpRequestLog
     @PutMapping("/posts/{postId}/write")
     public String updatePost(
             @PathVariable Long postId,

--- a/src/main/java/piglin/swapswap/global/annotation/HttpRequestLog.java
+++ b/src/main/java/piglin/swapswap/global/annotation/HttpRequestLog.java
@@ -1,0 +1,12 @@
+package piglin.swapswap.global.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface HttpRequestLog {
+
+}

--- a/src/main/java/piglin/swapswap/global/aspect/LogAspect.java
+++ b/src/main/java/piglin/swapswap/global/aspect/LogAspect.java
@@ -23,12 +23,17 @@ public class LogAspect {
     @Before("@annotation(piglin.swapswap.global.annotation.SwapLog)")
     public void swapLog(JoinPoint joinPoint) {
 
+        log.info("\nMethod - {} | Method Argument - {}",joinPoint.getSignature().getName(), joinPoint.getArgs());
+    }
+
+    @Before("@annotation(piglin.swapswap.global.annotation.HttpRequestLog)")
+    public void httpRequestLog(JoinPoint joinPoint) {
+
         MDC.put("traceId", UUID.randomUUID().toString());
 
         HttpServletRequest req = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
 
-        log.info("\nMethod - {} | Method Argument - {}\nIP - {} | Browser - {}\n▼ ▼ ▼ ▼ ▼ ▼ ▼ ▼ ▼ Cookie ▼ ▼ ▼ ▼ ▼ ▼ ▼ ▼ ▼\n{} \n▲ ▲ ▲ ▲ ▲ ▲ ▲ ▲ ▲ ▲ ▲ ▲ ▲ ▲ ▲ ▲ ▲ ▲ ▲ ▲ ▲",joinPoint.getSignature().getName(), joinPoint.getArgs(), getRemoteAddr(req), getBrowser(req),
-                getCookie(req));
+        log.info("\nIP - {} | Browser - {}\n▼ ▼ ▼ ▼ ▼ ▼ ▼ ▼ ▼ Cookie ▼ ▼ ▼ ▼ ▼ ▼ ▼ ▼ ▼\n{} \n▲ ▲ ▲ ▲ ▲ ▲ ▲ ▲ ▲ ▲ ▲ ▲ ▲ ▲ ▲ ▲ ▲ ▲ ▲ ▲ ▲", getRemoteAddr(req), getBrowser(req), getCookie(req));
     }
 
     @AfterReturning("@annotation(piglin.swapswap.global.annotation.SwapLog)")
@@ -44,7 +49,7 @@ public class LogAspect {
         MDC.clear();
     }
 
-    private static String getCookie(HttpServletRequest req) {
+    private String getCookie(HttpServletRequest req) {
         Cookie[] cookies = req.getCookies();
         StringBuilder cookieDetail = new StringBuilder();
 
@@ -60,7 +65,7 @@ public class LogAspect {
         return cookieDetail.toString();
     }
 
-    public static String getRemoteAddr(HttpServletRequest request) {
+    public String getRemoteAddr(HttpServletRequest request) {
         String ip = null;
         ip = request.getHeader("X-Forwarded-For");
         if (ip == null || ip.length() == 0 || "unknown".equalsIgnoreCase(ip)) {
@@ -90,7 +95,7 @@ public class LogAspect {
         return ip;
     }
 
-    public static String getBrowser(HttpServletRequest request) {
+    public String getBrowser(HttpServletRequest request) {
         // 에이전트
         String agent = request.getHeader("User-Agent");
         // 브라우져 구분


### PR DESCRIPTION
## 📝 개요
- [#244] 에 관한 내용입니다.
- 기존에는 Service 레이어 메소드에 @SwapLog 부착하고 HttpServletRequest를 받았습니다.
- 여기서 문제점이 통합 테스트를 실행할 때는 실질적으로 Controller 를 타고 요청이 오는 것이 아니라 HttpRequest가 없다는 것입니다.
- 통합 테스트 메서드 실행 -> 메서드에서 @SwapLog AOP 실행 -> HttpServletRequest로 로그 찍으려함 -> HttpServletRequest가 없음 -> 오류
<br>

## 👨‍💻 작업 내용
- HttpRequestLog 어노테이션을 만들고 기존 SwapLog 어노테이션 AOP에 있는 HttpRequest 관련된 코드들을 새로운 AOP로 분리해주었습니다.
<br>

## 🙇🏻‍♂️ 리뷰어에게
- 다른 더 좋은 방법이 있을까요? 하하
<br>
