### PR TITLE
Fix : 닉네임 수정이 되지 않던 버그 수정

### DIFF
--- a/src/main/java/piglin/swapswap/domain/member/service/MemberServiceImplV1.java
+++ b/src/main/java/piglin/swapswap/domain/member/service/MemberServiceImplV1.java
@@ -42,13 +42,13 @@ public class MemberServiceImplV1 implements MemberService {
         log.info("\nupdateNickname - memberId: {} | memberEmail: {} | memberCurrentNickname: {} | memberNicknameWillBe: {}",
                 member.getId(), member.getEmail(), member.getNickname(), requestDto.nickname());
 
-        Member isNotInTransactionMember = getMember(member.getId());
+        Member memberInTransaction = getMember(member.getId());
 
         if (memberRepository.existsByNicknameAndIsDeletedIsFalse(requestDto.nickname())) {
             throw new BusinessException(ErrorCode.ALREADY_EXIST_USER_NAME_EXCEPTION);
         }
 
-        isNotInTransactionMember.updateMember(requestDto.nickname());
+        memberInTransaction.updateMember(requestDto.nickname());
 
         log.info("\nmemberChangedNickname: {}", member.getNickname());
     }

--- a/src/main/java/piglin/swapswap/domain/member/service/MemberServiceImplV1.java
+++ b/src/main/java/piglin/swapswap/domain/member/service/MemberServiceImplV1.java
@@ -41,13 +41,15 @@ public class MemberServiceImplV1 implements MemberService {
 
         log.info("\nupdateNickname - memberId: {} | memberEmail: {} | memberCurrentNickname: {} | memberNicknameWillBe: {}",
                 member.getId(), member.getEmail(), member.getNickname(), requestDto.nickname());
-        checkMemberExists(member.getId());
+
+        Member isNotInTransactionMember = getMember(member.getId());
 
         if (memberRepository.existsByNicknameAndIsDeletedIsFalse(requestDto.nickname())) {
             throw new BusinessException(ErrorCode.ALREADY_EXIST_USER_NAME_EXCEPTION);
         }
 
-        member.updateMember(requestDto.nickname());
+        isNotInTransactionMember.updateMember(requestDto.nickname());
+
         log.info("\nmemberChangedNickname: {}", member.getNickname());
     }
 
@@ -124,12 +126,5 @@ public class MemberServiceImplV1 implements MemberService {
     public List<Member> getMembers(List<Long> memberIds) {
 
         return memberRepository.findByIdIn(memberIds);
-    }
-
-    public void checkMemberExists(Long memberId) {
-
-        if (!memberRepository.existsByIdAndIsDeletedIsFalse(memberId)) {
-            throw new BusinessException(ErrorCode.NOT_FOUND_USER_EXCEPTION);
-        }
     }
 }


### PR DESCRIPTION
## 📝 개요
- 닉네임 수정이 되지 않던 버그 수정
<br>

## 👨‍💻 작업 내용
- 변경감지가 일어나지 않아 @Transactional이 걸려있어도 닉네임이 수정되지 않았는데 isNotInTransactionMember라는 member를 만들어서 해결하였습니다
<br>

## 🙇🏻‍♂️ 리뷰어에게
- 네
<br>
