### PR TITLE
Feat: 레디스를 이용해 선착순 쿠폰 발급 성능 향상

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,6 +77,9 @@ dependencies {
 
     // web socket
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
+
+    // Redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('bootBuildImage') {

--- a/src/main/java/piglin/swapswap/domain/billcoupon/mapper/BillCouponMapper.java
+++ b/src/main/java/piglin/swapswap/domain/billcoupon/mapper/BillCouponMapper.java
@@ -12,7 +12,7 @@ public class BillCouponMapper {
             List<MemberCoupon> memberCouponList) {
 
         return memberCouponList.stream().map(memberCoupon -> BillCouponResponseDto.builder()
-                .name(memberCoupon.getName())
+                .name(memberCoupon.getCoupon().getName())
                 .build()).toList();
     }
 

--- a/src/main/java/piglin/swapswap/domain/billcoupon/repository/BillCouponQueryRepository.java
+++ b/src/main/java/piglin/swapswap/domain/billcoupon/repository/BillCouponQueryRepository.java
@@ -2,12 +2,13 @@ package piglin.swapswap.domain.billcoupon.repository;
 
 import java.util.List;
 import piglin.swapswap.domain.bill.entity.Bill;
+import piglin.swapswap.domain.billcoupon.dto.BillCouponResponseDto;
 import piglin.swapswap.domain.billcoupon.entity.BillCoupon;
 import piglin.swapswap.domain.membercoupon.entity.MemberCoupon;
 
 public interface BillCouponQueryRepository {
 
-    List<MemberCoupon> findMemberCouponFromBillCouponByBill(Bill bill);
+    List<BillCouponResponseDto> findMemberCouponFromBillCouponByBill(Bill bill);
 
     List<BillCoupon> findByBillWithMemberCoupon(Bill bill);
 

--- a/src/main/java/piglin/swapswap/domain/billcoupon/repository/BillCouponQueryRepositoryImpl.java
+++ b/src/main/java/piglin/swapswap/domain/billcoupon/repository/BillCouponQueryRepositoryImpl.java
@@ -1,14 +1,18 @@
 package piglin.swapswap.domain.billcoupon.repository;
 
 import static piglin.swapswap.domain.billcoupon.entity.QBillCoupon.billCoupon;
+import static piglin.swapswap.domain.coupon.entity.QCoupon.coupon;
 import static piglin.swapswap.domain.membercoupon.entity.QMemberCoupon.memberCoupon;
 
+import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
 import java.util.List;
 import piglin.swapswap.domain.bill.entity.Bill;
+import piglin.swapswap.domain.billcoupon.dto.BillCouponResponseDto;
 import piglin.swapswap.domain.billcoupon.entity.BillCoupon;
+import piglin.swapswap.domain.coupon.entity.QCoupon;
 import piglin.swapswap.domain.membercoupon.entity.MemberCoupon;
 
 public class BillCouponQueryRepositoryImpl implements BillCouponQueryRepository {
@@ -24,11 +28,13 @@ public class BillCouponQueryRepositoryImpl implements BillCouponQueryRepository 
     }
 
     @Override
-    public List<MemberCoupon> findMemberCouponFromBillCouponByBill(Bill bill) {
+    public List<BillCouponResponseDto> findMemberCouponFromBillCouponByBill(Bill bill) {
 
         return queryFactory
-                .select(memberCoupon)
+                .select(Projections.constructor(BillCouponResponseDto.class, coupon.name))
                 .from(billCoupon)
+                .join(billCoupon.memberCoupon, memberCoupon)
+                .join(memberCoupon.coupon, coupon)
                 .where(billCoupon.bill.eq(bill))
                 .fetch();
     }

--- a/src/main/java/piglin/swapswap/domain/coupon/controller/CouponController.java
+++ b/src/main/java/piglin/swapswap/domain/coupon/controller/CouponController.java
@@ -35,7 +35,7 @@ public class CouponController {
     @PostMapping("/event")
     public ResponseEntity<?> issueEventCoupon(@AuthMember Member member) {
 
-        couponService.issueEventCouponByPessimisticLock(EVENT_COUPON_ID, member);
+        couponService.issueEventCoupon(EVENT_COUPON_ID, member);
 
         return ResponseEntity.ok("쿠폰 발급 성공");
     }

--- a/src/main/java/piglin/swapswap/domain/coupon/service/CouponService.java
+++ b/src/main/java/piglin/swapswap/domain/coupon/service/CouponService.java
@@ -10,9 +10,7 @@ public interface CouponService {
 
     int getCouponCount(Long couponId);
 
-    void issueEventCouponByPessimisticLock(Long couponId, Member member);
-
-    void issueEventCouponByOptimisticLock(Long couponId, Member member);
+    void issueEventCoupon(Long couponId, Member member);
 
     CouponGetResponseDto getCouponDetail(Long couponId);
 

--- a/src/main/java/piglin/swapswap/domain/coupon/service/CouponServiceImplV2.java
+++ b/src/main/java/piglin/swapswap/domain/coupon/service/CouponServiceImplV2.java
@@ -13,7 +13,6 @@ import piglin.swapswap.domain.coupon.repository.CouponRepository;
 import piglin.swapswap.domain.coupon.validator.CouponValidator;
 import piglin.swapswap.domain.member.entity.Member;
 import piglin.swapswap.domain.membercoupon.service.MemberCouponService;
-import piglin.swapswap.global.annotation.SwapLog;
 import piglin.swapswap.global.exception.common.BusinessException;
 import piglin.swapswap.global.exception.common.ErrorCode;
 
@@ -48,7 +47,6 @@ public class CouponServiceImplV2 implements CouponService {
     }
 
     @Override
-    @SwapLog
     @Transactional
     public void issueEventCoupon(Long couponId, Member member) {
 

--- a/src/main/java/piglin/swapswap/domain/coupon/service/CouponServiceImplV2.java
+++ b/src/main/java/piglin/swapswap/domain/coupon/service/CouponServiceImplV2.java
@@ -3,6 +3,7 @@ package piglin.swapswap.domain.coupon.service;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 import piglin.swapswap.domain.coupon.dto.request.CouponCreateRequestDto;
@@ -13,15 +14,15 @@ import piglin.swapswap.domain.coupon.repository.CouponRepository;
 import piglin.swapswap.domain.coupon.validator.CouponValidator;
 import piglin.swapswap.domain.member.entity.Member;
 import piglin.swapswap.domain.membercoupon.service.MemberCouponService;
-import piglin.swapswap.global.annotation.Retry;
 import piglin.swapswap.global.annotation.SwapLog;
 import piglin.swapswap.global.exception.common.BusinessException;
 import piglin.swapswap.global.exception.common.ErrorCode;
 
 @Slf4j
 @Service
+@Primary
 @RequiredArgsConstructor
-public class CouponServiceImplV1 implements CouponService {
+public class CouponServiceImplV2 implements CouponService {
 
     private final CouponRepository couponRepository;
 
@@ -48,16 +49,15 @@ public class CouponServiceImplV1 implements CouponService {
         return coupon.getCount();
     }
 
-    @Retry
-    @SwapLog
     @Override
+    @SwapLog
     @Transactional
     public void issueEventCoupon(Long couponId, Member member) {
 
-        log.info("\ncouponIssue - member: {} | couponId: {} | transactionActive: {}", member.getEmail(), couponId,
+        log.info("\ncouponIssueStart - Member: {} | couponId: {} | transactionActive: {}", member.getEmail(), couponId,
                 TransactionSynchronizationManager.isActualTransactionActive());
 
-        Coupon coupon = couponRepository.findByIdWithOptimisticLock(couponId)
+        Coupon coupon = couponRepository.findByIdWithPessimisticLock(couponId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND_COUPON_EXCEPTION));
         log.info("\ncouponName: {} | couponType: {} | couponCountBeforeIssue: {}", coupon.getName(), coupon.getCouponType(), coupon.getCount());
 

--- a/src/main/java/piglin/swapswap/domain/coupon/service/CouponServiceImplV3.java
+++ b/src/main/java/piglin/swapswap/domain/coupon/service/CouponServiceImplV3.java
@@ -3,6 +3,8 @@ package piglin.swapswap.domain.coupon.service;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 import piglin.swapswap.domain.coupon.dto.request.CouponCreateRequestDto;
@@ -13,18 +15,20 @@ import piglin.swapswap.domain.coupon.repository.CouponRepository;
 import piglin.swapswap.domain.coupon.validator.CouponValidator;
 import piglin.swapswap.domain.member.entity.Member;
 import piglin.swapswap.domain.membercoupon.service.MemberCouponService;
-import piglin.swapswap.global.annotation.SwapLog;
 import piglin.swapswap.global.exception.common.BusinessException;
 import piglin.swapswap.global.exception.common.ErrorCode;
 
 @Slf4j
 @Service
+@Primary
 @RequiredArgsConstructor
-public class CouponServiceImplV2 implements CouponService {
+public class CouponServiceImplV3 implements CouponService{
 
     private final CouponRepository couponRepository;
 
     private final MemberCouponService memberCouponService;
+
+    private final RedisTemplate<String, Integer> redisTemplate;
 
     @Override
     public Long createCoupon(CouponCreateRequestDto couponCreateRequestDto) {
@@ -35,6 +39,8 @@ public class CouponServiceImplV2 implements CouponService {
 
         Coupon savedCoupon = couponRepository.save(coupon);
 
+        redisTemplate.opsForValue().set(coupon.getName(), 0);
+
         return savedCoupon.getId();
     }
 
@@ -44,32 +50,36 @@ public class CouponServiceImplV2 implements CouponService {
         Coupon coupon = couponRepository.findById(couponId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND_COUPON_EXCEPTION));
 
-        return coupon.getCount();
+        int couponNumber = redisTemplate.opsForValue().get(coupon.getName());
+
+        return coupon.getCount() - couponNumber;
     }
 
     @Override
-    @SwapLog
     @Transactional
     public void issueEventCoupon(Long couponId, Member member) {
 
         log.info("\ncouponIssueStart - Member: {} | couponId: {} | transactionActive: {}", member.getEmail(), couponId,
                 TransactionSynchronizationManager.isActualTransactionActive());
 
-        Coupon coupon = couponRepository.findByIdWithPessimisticLock(couponId)
+        Coupon coupon = couponRepository.findById(couponId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND_COUPON_EXCEPTION));
         log.info("\ncouponName: {} | couponType: {} | couponCountBeforeIssue: {}", coupon.getName(), coupon.getCouponType(), coupon.getCount());
+        int couponNumber = redisTemplate.opsForValue().get(coupon.getName());
 
-        log.info("\nissueCouponPossible: {}", issueCouponPossible(coupon));
-        if (issueCouponPossible(coupon)) {
+        redisTemplate.opsForValue().increment(coupon.getName());
+
+        log.info("\nissueCouponPossible: {}", issueCouponPossible(coupon.getCount(), 0L));
+        if (issueCouponPossible(coupon.getCount(), 0L)) {
             memberCouponService.saveMemberCoupon(member, coupon);
             coupon.issueCoupon();
             log.info("\ncouponCountAfterIssue: {}", coupon.getCount());
         }
     }
 
-    public boolean issueCouponPossible(Coupon coupon) {
+    public boolean issueCouponPossible(int couponCount, Long couponNumber) {
 
-        return coupon.getCount() > 0;
+        return couponCount >= couponNumber;
     }
 
     @Override

--- a/src/main/java/piglin/swapswap/domain/coupon/service/CouponServiceImplV3.java
+++ b/src/main/java/piglin/swapswap/domain/coupon/service/CouponServiceImplV3.java
@@ -65,14 +65,12 @@ public class CouponServiceImplV3 implements CouponService{
         Coupon coupon = couponRepository.findById(couponId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND_COUPON_EXCEPTION));
         log.info("\ncouponName: {} | couponType: {} | couponCountBeforeIssue: {}", coupon.getName(), coupon.getCouponType(), coupon.getCount());
-        int couponNumber = redisTemplate.opsForValue().get(coupon.getName());
 
-        redisTemplate.opsForValue().increment(coupon.getName());
+        Long couponNumber = redisTemplate.opsForValue().increment(coupon.getName());
 
-        log.info("\nissueCouponPossible: {}", issueCouponPossible(coupon.getCount(), 0L));
-        if (issueCouponPossible(coupon.getCount(), 0L)) {
+        log.info("\nissueCouponPossible: {}", issueCouponPossible(coupon.getCount(), couponNumber));
+        if (issueCouponPossible(coupon.getCount(), couponNumber)) {
             memberCouponService.saveMemberCoupon(member, coupon);
-            coupon.issueCoupon();
             log.info("\ncouponCountAfterIssue: {}", coupon.getCount());
         }
     }

--- a/src/main/java/piglin/swapswap/domain/membercoupon/entity/MemberCoupon.java
+++ b/src/main/java/piglin/swapswap/domain/membercoupon/entity/MemberCoupon.java
@@ -17,6 +17,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import piglin.swapswap.domain.common.BaseTime;
 import piglin.swapswap.domain.coupon.constant.CouponType;
+import piglin.swapswap.domain.coupon.entity.Coupon;
 import piglin.swapswap.domain.member.entity.Member;
 
 @Entity
@@ -30,25 +31,13 @@ public class MemberCoupon extends BaseTime {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(length = 60, nullable = false)
-    private String name;
-
-    @Column(nullable = false)
-    @Enumerated(EnumType.STRING)
-    private CouponType couponType;
-
-    @Column(nullable = false)
-    private int discountPercentage;
-
-    @Column(nullable = false)
-    private LocalDateTime expiredTime;
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "coupon_id", nullable = false)
+    private Coupon coupon;
 
     @ManyToOne(optional = false)
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
-
-    @Column(nullable = false)
-    private Boolean isDeleted;
 
     @Column(nullable = false)
     private Boolean isUsed;

--- a/src/main/java/piglin/swapswap/domain/membercoupon/mapper/MemberCouponMapper.java
+++ b/src/main/java/piglin/swapswap/domain/membercoupon/mapper/MemberCouponMapper.java
@@ -6,17 +6,15 @@ import piglin.swapswap.domain.member.entity.Member;
 import piglin.swapswap.domain.membercoupon.dto.response.MyCouponGetResponseDto;
 import piglin.swapswap.domain.membercoupon.entity.MemberCoupon;
 
+import static java.util.stream.Collectors.toList;
+
 public class MemberCouponMapper {
 
     public static MemberCoupon createMemberCoupon(Member member, Coupon coupon) {
 
         return MemberCoupon.builder()
-                .name(coupon.getName())
-                .couponType(coupon.getCouponType())
-                .discountPercentage(coupon.getDiscountPercentage())
-                .expiredTime(coupon.getExpiredTime())
+                .coupon(coupon)
                 .member(member)
-                .isDeleted(false)
                 .isUsed(false)
                 .build();
     }
@@ -25,12 +23,15 @@ public class MemberCouponMapper {
             List<MemberCoupon> memberCouponList) {
 
         return memberCouponList.stream().map(memberCoupon ->
-                MyCouponGetResponseDto.builder()
-                                      .couponId(memberCoupon.getId())
-                                      .couponName(memberCoupon.getName())
-                                      .couponType(memberCoupon.getCouponType())
-                                      .discountPercentage(memberCoupon.getDiscountPercentage())
-                                      .expiredTime(memberCoupon.getExpiredTime())
-                                      .build()).toList();
+        {
+            Coupon coupon = memberCoupon.getCoupon();
+            return MyCouponGetResponseDto.builder()
+                    .couponId(memberCoupon.getId())
+                    .couponName(coupon.getName())
+                    .couponType(coupon.getCouponType())
+                    .discountPercentage(coupon.getDiscountPercentage())
+                    .expiredTime(coupon.getExpiredTime())
+                    .build();
+        }).toList();
     }
 }

--- a/src/main/java/piglin/swapswap/domain/membercoupon/repository/MemberCouponQueryRepository.java
+++ b/src/main/java/piglin/swapswap/domain/membercoupon/repository/MemberCouponQueryRepository.java
@@ -1,6 +1,8 @@
 package piglin.swapswap.domain.membercoupon.repository;
 
 import piglin.swapswap.domain.member.entity.Member;
+
+import java.util.List;
 import java.util.Optional;
 import piglin.swapswap.domain.membercoupon.entity.MemberCoupon;
 
@@ -10,6 +12,14 @@ public interface MemberCouponQueryRepository {
 
     void reRegisterCouponByMember(Member loginMember);
 
-    Optional<MemberCoupon> findByIdAndIsUserIsFalseWithMember(Long memberCouponId);
+    Optional<MemberCoupon> findByMemberCouponIdAndIsUsedIsFalseWithCoupon(Long memberCouponId);
+
+    Optional<MemberCoupon> findByIdAndIsUsedIsFalseWithCoupon(Long memberCouponId);
+
+    Optional<MemberCoupon> findByIdAndIsUsedIsFalseWithCouponAndMember(Long memberCouponId);
+
+    Long countByCouponId(Long couponId);
+
+    List<MemberCoupon> findAllByMemberIdAndIsUsedIsFalseWithCoupon(Long memberId);
 }
 

--- a/src/main/java/piglin/swapswap/domain/membercoupon/repository/MemberCouponQueryRepositoryImpl.java
+++ b/src/main/java/piglin/swapswap/domain/membercoupon/repository/MemberCouponQueryRepositoryImpl.java
@@ -1,17 +1,23 @@
 package piglin.swapswap.domain.membercoupon.repository;
 
+import static piglin.swapswap.domain.coupon.entity.QCoupon.coupon;
+import static piglin.swapswap.domain.member.entity.QMember.member;
 import static piglin.swapswap.domain.membercoupon.entity.QMemberCoupon.memberCoupon;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
+import piglin.swapswap.domain.coupon.entity.QCoupon;
 import piglin.swapswap.domain.member.entity.Member;
 import com.querydsl.core.types.dsl.BooleanExpression;
+
+import java.util.List;
 import java.util.Optional;
+
 import piglin.swapswap.domain.member.entity.QMember;
 import piglin.swapswap.domain.membercoupon.entity.MemberCoupon;
 import piglin.swapswap.domain.membercoupon.entity.QMemberCoupon;
 
-public class MemberCouponQueryRepositoryImpl implements MemberCouponQueryRepository{
+public class MemberCouponQueryRepositoryImpl implements MemberCouponQueryRepository {
 
     private final EntityManager em;
     private final JPAQueryFactory queryFactory;
@@ -22,10 +28,10 @@ public class MemberCouponQueryRepositoryImpl implements MemberCouponQueryReposit
     }
 
     @Override
-    public void deleteAllMemberCouponByMember(Member loginMember){
+    public void deleteAllMemberCouponByMember(Member loginMember) {
         queryFactory
                 .update(memberCoupon)
-                .set(memberCoupon.isDeleted, true)
+                .set(memberCoupon.isUsed, true)
                 .where(memberCoupon.member.eq(loginMember))
                 .execute();
 
@@ -37,24 +43,86 @@ public class MemberCouponQueryRepositoryImpl implements MemberCouponQueryReposit
     public void reRegisterCouponByMember(Member loginMember) {
         queryFactory
                 .update(memberCoupon)
-                .set(memberCoupon.isDeleted, false)
+                .set(memberCoupon.isUsed, false)
                 .where(memberCoupon.member.eq(loginMember))
                 .execute();
 
         em.flush();
         em.clear();
     }
-    public Optional<MemberCoupon> findByIdAndIsUserIsFalseWithMember(Long memberCouponId) {
+
+    public Optional<MemberCoupon> findByIdAndIsUsedIsFalseWithMember(Long memberCouponId) {
 
         return Optional.ofNullable(queryFactory
-                .selectFrom(QMemberCoupon.memberCoupon)
-                .join(QMemberCoupon.memberCoupon.member, QMember.member).fetchJoin()
-                .where(memberCouponIdEq(memberCouponId))
+                .selectFrom(memberCoupon)
+                .join(memberCoupon.member, member).fetchJoin()
+                .where(memberCouponIdEq(memberCouponId).and(isUsedIsFalse()))
                 .fetchOne());
+    }
+
+    @Override
+    public Optional<MemberCoupon> findByMemberCouponIdAndIsUsedIsFalseWithCoupon(Long memberCouponId) {
+        return Optional.ofNullable(queryFactory
+                .selectFrom(memberCoupon)
+                .join(memberCoupon.coupon, coupon).fetchJoin()
+                .where(memberCouponIdEq(memberCouponId).and(isUsedIsFalse()))
+                .fetchOne());
+    }
+
+    @Override
+    public Optional<MemberCoupon> findByIdAndIsUsedIsFalseWithCoupon(Long memberCouponId) {
+        return Optional.ofNullable(queryFactory
+                .selectFrom(memberCoupon)
+                .join(memberCoupon.coupon, QCoupon.coupon).fetchJoin()
+                .where(memberCouponIdEq(memberCouponId).and(isUsedIsFalse()))
+                .fetchOne());
+    }
+
+    @Override
+    public Optional<MemberCoupon> findByIdAndIsUsedIsFalseWithCouponAndMember(Long memberCouponId) {
+        return Optional.ofNullable(queryFactory
+                .selectFrom(memberCoupon)
+                .join(memberCoupon.coupon, coupon).fetchJoin()
+                .join(memberCoupon.member, member).fetchJoin()
+                .where(memberCouponIdEq(memberCouponId).and(isUsedIsFalse()))
+                .fetchOne());
+    }
+
+    @Override
+    public Long countByCouponId(Long couponId) {
+        return queryFactory
+                .select(memberCoupon.count())
+                .from(memberCoupon)
+                .where(couponIdEq(couponId))
+                .fetchOne();
+    }
+
+    @Override
+    public List<MemberCoupon> findAllByMemberIdAndIsUsedIsFalseWithCoupon(Long memberId) {
+        return queryFactory
+                .selectFrom(memberCoupon)
+                .join(memberCoupon.coupon).fetchJoin()
+                .where(memberIdEq(memberId).and(isUsedIsFalse()))
+                .fetch();
     }
 
     private BooleanExpression memberCouponIdEq(Long memberCouponId) {
 
-        return QMemberCoupon.memberCoupon.id.eq(memberCouponId);
+        return memberCoupon.id.eq(memberCouponId);
+    }
+
+    private BooleanExpression couponIdEq(Long couponId) {
+
+        return memberCoupon.coupon.id.eq(couponId);
+    }
+
+    private BooleanExpression isUsedIsFalse() {
+        return memberCoupon.isUsed.eq(false);
+    }
+
+    private BooleanExpression memberIdEq(Long memberId) {
+
+        return memberCoupon.member.id.eq(memberId);
     }
 }
+

--- a/src/main/java/piglin/swapswap/domain/membercoupon/repository/MemberCouponRepository.java
+++ b/src/main/java/piglin/swapswap/domain/membercoupon/repository/MemberCouponRepository.java
@@ -8,11 +8,7 @@ import piglin.swapswap.domain.membercoupon.entity.MemberCoupon;
 
 public interface MemberCouponRepository extends JpaRepository<MemberCoupon, Long>, MemberCouponQueryRepository {
 
-    List<MemberCoupon> findByMemberIdAndIsDeletedIsFalse(Long id);
-
-    List<MemberCoupon> findAllByMemberIdAndIsUsedIsFalse(Long memberId);
-
-    void deleteAllByIsDeletedIsTrueAndModifiedTimeBefore(LocalDateTime fourteenDaysAgo);
+    void deleteAllByIsUsedIsTrueAndModifiedTimeBefore(LocalDateTime fourteenDaysAgo);
 
     Optional<MemberCoupon> findByIdAndIsUsedFalse(Long couponId);
 }

--- a/src/main/java/piglin/swapswap/domain/membercoupon/service/MemberCouponService.java
+++ b/src/main/java/piglin/swapswap/domain/membercoupon/service/MemberCouponService.java
@@ -12,13 +12,13 @@ public interface MemberCouponService {
 
     List<MyCouponGetResponseDto> getMycouponList(Member member);
 
-    MemberCoupon getMemberCouponById(Long memberCouponId);
+    MemberCoupon getMemberCouponWithCouponById(Long memberCouponId);
 
-    void deleteMemberCoupon(MemberCoupon memberCoupon);
-
-    MemberCoupon getMemberCouponByIdWithMember(Long memberCouponId);
+    MemberCoupon getMemberCouponWithCouponByMemberCouponId(Long couponId);
 
     void deleteAllMemberCouponByMember(Member loginMember);
 
     void reRegisterCouponByMember(Member loginMember);
+
+    Long getCountByCouponId(Long couponId);
 }

--- a/src/main/java/piglin/swapswap/domain/membercoupon/service/MemberCouponServiceImplV1.java
+++ b/src/main/java/piglin/swapswap/domain/membercoupon/service/MemberCouponServiceImplV1.java
@@ -1,6 +1,7 @@
 package piglin.swapswap.domain.membercoupon.service;
 
 import java.util.List;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -10,13 +11,12 @@ import piglin.swapswap.domain.membercoupon.dto.response.MyCouponGetResponseDto;
 import piglin.swapswap.domain.membercoupon.entity.MemberCoupon;
 import piglin.swapswap.domain.membercoupon.mapper.MemberCouponMapper;
 import piglin.swapswap.domain.membercoupon.repository.MemberCouponRepository;
-import piglin.swapswap.global.exception.common.BusinessException;
-import piglin.swapswap.global.exception.common.ErrorCode;
+import piglin.swapswap.global.exception.membercoupon.MemberCouponNotFoundException;
 
 @Service
 @Slf4j
 @RequiredArgsConstructor
-public class MemberCouponServiceImplV1 implements MemberCouponService{
+public class MemberCouponServiceImplV1 implements MemberCouponService {
 
     private final MemberCouponRepository memberCouponRepository;
 
@@ -25,14 +25,15 @@ public class MemberCouponServiceImplV1 implements MemberCouponService{
 
         MemberCoupon memberCoupon = MemberCouponMapper.createMemberCoupon(member, coupon);
         log.info("\nmemberCouponSave - member: {}, memberCouponName: {}, memberCouponType: {}",
-                memberCoupon.getMember().getEmail(), memberCoupon.getName(), memberCoupon.getCouponType());
+                memberCoupon.getMember().getEmail(), memberCoupon.getCoupon().getName(), memberCoupon.getCoupon().getCouponType());
+
         memberCouponRepository.save(memberCoupon);
     }
 
     @Override
     public List<MyCouponGetResponseDto> getMycouponList(Member member) {
 
-        List<MemberCoupon> memberCouponList = memberCouponRepository.findAllByMemberIdAndIsUsedIsFalse(
+        List<MemberCoupon> memberCouponList = memberCouponRepository.findAllByMemberIdAndIsUsedIsFalseWithCoupon(
                 member.getId());
 
         return MemberCouponMapper.memberCouponListToMyCouponResponseDtoList(memberCouponList);
@@ -48,23 +49,22 @@ public class MemberCouponServiceImplV1 implements MemberCouponService{
     }
 
     @Override
-    public MemberCoupon getMemberCouponById(Long memberCouponId) {
+    public Long getCountByCouponId(Long couponId) {
 
-        return  memberCouponRepository.findByIdAndIsUsedFalse(memberCouponId).orElseThrow(
-                () -> new BusinessException(ErrorCode.NOT_FOUND_COUPON_EXCEPTION)
-        );
+        return memberCouponRepository.countByCouponId(couponId);
     }
 
     @Override
-    public void deleteMemberCoupon(MemberCoupon memberCoupon) {
-
-        memberCouponRepository.delete(memberCoupon);
+    public MemberCoupon getMemberCouponWithCouponById(Long memberCouponId) {
+        return memberCouponRepository.findByIdAndIsUsedIsFalseWithCoupon(memberCouponId)
+                .orElseThrow(MemberCouponNotFoundException::new);
     }
 
     @Override
-    public MemberCoupon getMemberCouponByIdWithMember(Long memberCouponId) {
+    public MemberCoupon getMemberCouponWithCouponByMemberCouponId(Long memberCouponId) {
 
-        return memberCouponRepository.findByIdAndIsUserIsFalseWithMember(memberCouponId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND_COUPON_EXCEPTION));
+        return memberCouponRepository.findByMemberCouponIdAndIsUsedIsFalseWithCoupon(memberCouponId)
+                .orElseThrow(MemberCouponNotFoundException::new);
     }
+
 }

--- a/src/main/java/piglin/swapswap/global/config/RedisConfig.java
+++ b/src/main/java/piglin/swapswap/global/config/RedisConfig.java
@@ -6,7 +6,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
 public class RedisConfig {
@@ -26,7 +25,8 @@ public class RedisConfig {
     public RedisTemplate<?, ?> redisTemplate() {
         RedisTemplate<byte[], byte[]> redisTemplate = new RedisTemplate<>();
         redisTemplate.setConnectionFactory(redisConnectionFactory());
-        redisTemplate.setHashValueSerializer(new StringRedisSerializer());
+//        redisTemplate.setKeySerializer(new StringRedisSerializer());
+//        redisTemplate.setValueSerializer(new StringRedisSerializer());
         return redisTemplate;
     }
 

--- a/src/main/java/piglin/swapswap/global/config/RedisConfig.java
+++ b/src/main/java/piglin/swapswap/global/config/RedisConfig.java
@@ -1,0 +1,33 @@
+package piglin.swapswap.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String redisHost;
+
+    @Value("${spring.data.redis.port}")
+    private int redisPort;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(redisHost, redisPort);
+    }
+
+    @Bean
+    public RedisTemplate<?, ?> redisTemplate() {
+        RedisTemplate<byte[], byte[]> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setHashValueSerializer(new StringRedisSerializer());
+        return redisTemplate;
+    }
+
+}

--- a/src/main/java/piglin/swapswap/global/config/RedisConfig.java
+++ b/src/main/java/piglin/swapswap/global/config/RedisConfig.java
@@ -6,6 +6,8 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
 public class RedisConfig {
@@ -25,8 +27,8 @@ public class RedisConfig {
     public RedisTemplate<?, ?> redisTemplate() {
         RedisTemplate<byte[], byte[]> redisTemplate = new RedisTemplate<>();
         redisTemplate.setConnectionFactory(redisConnectionFactory());
-//        redisTemplate.setKeySerializer(new StringRedisSerializer());
-//        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer<>(Integer.class));
         return redisTemplate;
     }
 

--- a/src/main/java/piglin/swapswap/global/exception/common/ErrorCode.java
+++ b/src/main/java/piglin/swapswap/global/exception/common/ErrorCode.java
@@ -51,6 +51,7 @@ public enum ErrorCode {
     INVALID_EXPIRED_TIME_EXCEPTION(401, "만료 시간은 현재 시간보다 이전 시간일 수 없습니다."),
     NOT_FOUND_COUPON_EXCEPTION(401, "쿠폰을 찾을 수 없습니다."),
     INVALID_COUPON_EXCEPTION(401, "이미 모두 소진된 쿠폰입니다."),
+    NOT_FOUND_MEMBER_COUPON_EXCEPTION(400, "해당 쿠폰을 소지하고 있지 않습니다."),
 
     // 거래
     BOTH_POST_ID_LIST_EMPTY_EXCEPTION(400, "두명의 사용자 중 적어도 한명의 사용자는 물건을 등록해야 합니다."),

--- a/src/main/java/piglin/swapswap/global/exception/membercoupon/MemberCouponNotFoundException.java
+++ b/src/main/java/piglin/swapswap/global/exception/membercoupon/MemberCouponNotFoundException.java
@@ -1,0 +1,10 @@
+package piglin.swapswap.global.exception.membercoupon;
+
+import piglin.swapswap.global.exception.common.BusinessException;
+import piglin.swapswap.global.exception.common.ErrorCode;
+
+public class MemberCouponNotFoundException extends BusinessException {
+    public MemberCouponNotFoundException() {
+        super(ErrorCode.NOT_FOUND_MEMBER_COUPON_EXCEPTION);
+    }
+}

--- a/src/main/java/piglin/swapswap/global/scheduler/Scheduler.java
+++ b/src/main/java/piglin/swapswap/global/scheduler/Scheduler.java
@@ -38,7 +38,7 @@ public class Scheduler {
         LocalDateTime fourteenDaysAgo = LocalDateTime.now().minusDays(14);
 
         walletHistoryRepository.deleteAllByIsDeletedIsTrueAndModifiedTimeBefore(fourteenDaysAgo);
-        memberCouponRepository.deleteAllByIsDeletedIsTrueAndModifiedTimeBefore(fourteenDaysAgo);
+        memberCouponRepository.deleteAllByIsUsedIsTrueAndModifiedTimeBefore(fourteenDaysAgo);
         chatRoomRepository.deleteAllByIsDeletedIsTrueAndModifiedTimeBefore(fourteenDaysAgo);
         favoriteRepository.deleteAllByIsDeletedIsTrueAndModifiedTimeBefore(fourteenDaysAgo);
 

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -22,6 +22,10 @@ spring:
     hiddenmethod:
       filter:
         enabled: true
+  data:
+    redis:
+      host: 127.0.0.1
+      port: 6379
 
 jwt:
   secret:
@@ -54,3 +58,4 @@ kakao:
   client:
     id: ENC(DmCqicA7Pa7EFxu5XTVtBxYl3K6fHeM1nSl090T2k+aJXj/JxcAnC1++VMpiz2ZU)
   redirect-uri: http://localhost:8080/login/kakao/callback
+

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -18,6 +18,11 @@ spring:
       max-file-size: 10MB
       max-request-size: 100MB
 
+  data:
+    redis:
+      host: 127.0.0.1
+      port: 6379
+
 jwt:
   secret:
     key: ENC(vvNeDy5afcRKYPy6Pdy2uIGfROZ6ZVGaYEBgaBPs4cttxYsNvS8PD5Xv9DNMC8tU/gxMtW2wHf4M7igHTjZBLUazfi8m3OyxWbDjXIyup4HAfvN9YrMmnAVTN1fAMKsC)


### PR DESCRIPTION
## 📝 개요
- 레디스를 이용해 선착순 쿠폰 발급 성능 향상
<br>

## 👨‍💻 작업 내용
- 쿠폰 - 멤버 쿠폰 연관관계 형성
- CouponService V1(낙관적 락) -> V2(비관적 락) -> V3(레디스)로 분리
- 레디스의 INCR 메서드를 이용해 선착순 쿠폰 발급 성능 향상
- 두 지표, 모두 JVM의 Warm-up Time을 고려해 2번 이상 테스트를 진행하였습니다. 지금 표로 보아선 TPS는 차이가 크게 없어보이고, MTT에 대해서 레디스가 훨씬 우수하여 전체 테스트 시간 또한 짧은 것을 볼 수 있습니다. 더 자세한 분석은 추후에 진행하여 작성하도록 하겠습니다.
- 기존 비관적 락
![image](https://github.com/Team-Piglin/swapswap/assets/40788498/d6958458-e093-4d95-b6fa-74436c08cdb4)

-레디스로 교체 후
![image](https://github.com/Team-Piglin/swapswap/assets/40788498/43c5da78-0256-4122-91ac-ebefd965fe1f)

<br>

## 🙇🏻‍♂️ 리뷰어에게
- 생각보다 DB 락도 빠르다는 것을 알게된 계기가 된 것 같습니다.
<br>
