### PR TITLE
feat: delete Scheduler 한시적 미사용 변경

### DIFF
--- a/src/main/java/piglin/swapswap/global/scheduler/Scheduler.java
+++ b/src/main/java/piglin/swapswap/global/scheduler/Scheduler.java
@@ -1,66 +1,52 @@
 package piglin.swapswap.global.scheduler;
 
-import jakarta.transaction.Transactional;
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
-import piglin.swapswap.domain.chatroom.mongorepository.ChatRoomRepository;
-import piglin.swapswap.domain.favorite.repository.FavoriteRepository;
-import piglin.swapswap.domain.member.repository.MemberRepository;
-import piglin.swapswap.domain.membercoupon.repository.MemberCouponRepository;
-import piglin.swapswap.domain.post.entity.Post;
-import piglin.swapswap.domain.post.event.DeleteImageUrlListEvent;
-import piglin.swapswap.domain.post.repository.PostRepository;
-import piglin.swapswap.domain.wallet.repository.WalletRepository;
-import piglin.swapswap.domain.wallethistory.repository.WalletHistoryRepository;
 
 @Component
 @RequiredArgsConstructor
 public class Scheduler {
 
-    private final MemberRepository memberRepository;
-    private final PostRepository postRepository;
-    private final FavoriteRepository favoriteRepository;
-    private final WalletRepository walletRepository;
-    private final MemberCouponRepository memberCouponRepository;
-    private final ChatRoomRepository chatRoomRepository;
-    private final WalletHistoryRepository walletHistoryRepository;
-    private final ApplicationEventPublisher applicationEventPublisher;
-
-    @Transactional
-    @Scheduled(cron = "0 0 0 * * *")
-    public void deleteExpiredWalletHistory() {
-
-        LocalDateTime fourteenDaysAgo = LocalDateTime.now().minusDays(14);
-
-        walletHistoryRepository.deleteAllByIsDeletedIsTrueAndModifiedTimeBefore(fourteenDaysAgo);
-        memberCouponRepository.deleteAllByIsUsedIsTrueAndModifiedTimeBefore(fourteenDaysAgo);
-        chatRoomRepository.deleteAllByIsDeletedIsTrueAndModifiedTimeBefore(fourteenDaysAgo);
-        favoriteRepository.deleteAllByIsDeletedIsTrueAndModifiedTimeBefore(fourteenDaysAgo);
-
-        List<String> postImageUrlListToDelete = new ArrayList<>();
-
-
-        List<Post> postListToDelete = postRepository.findByIsDeletedIsTrueAndModifiedTimeBefore(fourteenDaysAgo);
-
-        for(Post post : postListToDelete) {
-
-            for (int i = 0; i < post.getImageUrl().size(); i++) {
-                postImageUrlListToDelete.add((String) post.getImageUrl().get(i));
-            }
-        }
-
-        applicationEventPublisher.publishEvent(new DeleteImageUrlListEvent(postImageUrlListToDelete));
-
-        postRepository.deleteAll(postListToDelete);
-
-        memberRepository.deleteAllByIsDeletedIsTrueAndModifiedTimeBefore(fourteenDaysAgo);
-
-        walletRepository.deleteAllByIsDeletedIsTrueAndModifiedTimeBefore(fourteenDaysAgo);
-
-    }
+//    private final MemberRepository memberRepository;
+//    private final PostRepository postRepository;
+//    private final FavoriteRepository favoriteRepository;
+//    private final WalletRepository walletRepository;
+//    private final MemberCouponRepository memberCouponRepository;
+//    private final ChatRoomRepository chatRoomRepository;
+//    private final WalletHistoryRepository walletHistoryRepository;
+//    private final ApplicationEventPublisher applicationEventPublisher;
+//
+//    @Transactional
+//    @Scheduled(cron = "0 0 0 * * *")
+//    public void deleteExpiredWalletHistory() {
+//
+//        LocalDateTime fourteenDaysAgo = LocalDateTime.now().minusDays(14);
+//
+//        walletHistoryRepository.deleteAllByIsDeletedIsTrueAndModifiedTimeBefore(fourteenDaysAgo);
+//        memberCouponRepository.deleteAllByIsUsedIsTrueAndModifiedTimeBefore(fourteenDaysAgo);
+//        chatRoomRepository.deleteAllByIsDeletedIsTrueAndModifiedTimeBefore(fourteenDaysAgo);
+//        favoriteRepository.deleteAllByIsDeletedIsTrueAndModifiedTimeBefore(fourteenDaysAgo);
+//
+//        List<String> postImageUrlListToDelete = new ArrayList<>();
+//
+//
+//        List<Post> postListToDelete = postRepository.findByIsDeletedIsTrueAndModifiedTimeBefore(fourteenDaysAgo);
+//
+//        for(Post post : postListToDelete) {
+//
+//            for (int i = 0; i < post.getImageUrl().size(); i++) {
+//                postImageUrlListToDelete.add((String) post.getImageUrl().get(i));
+//            }
+//        }
+//
+//        applicationEventPublisher.publishEvent(new DeleteImageUrlListEvent(postImageUrlListToDelete));
+//
+//        postRepository.deleteAll(postListToDelete);
+//
+//        memberRepository.deleteAllByIsDeletedIsTrueAndModifiedTimeBefore(fourteenDaysAgo);
+//
+//        walletRepository.deleteAllByIsDeletedIsTrueAndModifiedTimeBefore(fourteenDaysAgo);
+//
+//    }
+    // TODO 탈퇴한 멤버 중요 정보 NULL 값으로 바꾸기
 }


### PR DESCRIPTION
## 📝 개요
- 기존 테이블에서 V2 테이블로 업데이트하면서 탈퇴하더라도 연관관계를 끊지 않는 식으로 결정했습니다.
- 추후 고객 중요정보는 Null 값으로 바꾸는 로직을 넣을 것이나, 현재는 배포를 우선적으로 하기 위해 기존 로직들 주석처리하였습니다.
<br>

## 👨‍💻 작업 내용
- delete Scheduler 한시적 미사용 변경
<br>

## 🙇🏻‍♂️ 리뷰어에게
- 쓱 봐주세요~
<br>
