### PR TITLE
Fix: 변수명이 달라 Controller에서 파라미터를 받지 못하던 부분 해결

### DIFF
--- a/src/main/resources/templates/post/post.html
+++ b/src/main/resources/templates/post/post.html
@@ -219,7 +219,7 @@
       $.ajax({
         url: '/chats/create',
         type: 'POST',
-        data: {receiveMemberId: userId},
+        data: {secondMemberId: userId},
 
         success: function (response) {
           console.log(response);


### PR DESCRIPTION
## 📝 개요
- 변수명이 달라 Controller에서 파라미터를 받지 못하던 부분을 수정했습니다
<br>

## 👨‍💻 작업 내용
- post.html에서 변수명 변경 : receiveMemberId -> secondMemberId<br>

## 🙇🏻‍♂️ 리뷰어에게
- 리뷰어에게 중점적으로 봐줬으면 하는 부분을 입력하세요.
<br>
