### PR TITLE
fix: 게시글 검색 띄어쓰기 일치해도 검색 안되는 오류 수정

### DIFF
--- a/src/main/java/piglin/swapswap/domain/post/repository/PostQueryRepository.java
+++ b/src/main/java/piglin/swapswap/domain/post/repository/PostQueryRepository.java
@@ -14,7 +14,7 @@ public interface PostQueryRepository {
     List<PostListDetailResponseDto> findPostListWithFavoriteByCursor(
             Member member, LocalDateTime cursorTime);
 
-    List<PostListDetailResponseDto> searchPostListWithFavorite(String title, Category categoryCond,
+    List<PostListDetailResponseDto> searchPostListWithFavorite(String titleCond, Category categoryCond,
             City cityCond, Member member, LocalDateTime cursorTime);
 
     PostGetResponseDto findPostWithFavorite(Long postId, Member member);

--- a/src/main/java/piglin/swapswap/domain/post/service/PostServiceImplV1.java
+++ b/src/main/java/piglin/swapswap/domain/post/service/PostServiceImplV1.java
@@ -140,6 +140,7 @@ public class PostServiceImplV1 implements PostService {
 
         Category categoryCond = null;
         City cityCond = null;
+        String titleCond = title.replaceAll(" ", "");
 
         if (category != null) {
             categoryCond = Enum.valueOf(Category.class, category);
@@ -150,7 +151,7 @@ public class PostServiceImplV1 implements PostService {
         }
 
         List<PostListDetailResponseDto> postList = postRepository.searchPostListWithFavorite(
-                title, categoryCond, cityCond, member, cursorTime);
+                titleCond, categoryCond, cityCond, member, cursorTime);
 
         return createPostListResponseDtoWithIsLast(postList);
     }


### PR DESCRIPTION
## 📝 개요
- 게시글 검색 시 띄어쓰기가 일치해도 검색이 안됐습니다.
<br>

## 👨‍💻 작업 내용
- param으로 들어온 내용의 띄어쓰기를 안 빼줘서 생기는 오류였습니다.
- param으로 받은 문자열의 공백을 제거해주는 로직을 추가했습니다.
<br>

## 🙇🏻‍♂️ 리뷰어에게
- 쓱 봐주세요!
<br>
