### PR TITLE
fix: 멤버 프로필 게시글 조회 다른 멤버 게시글 불러오는 문제 해결

### DIFF
--- a/src/main/java/piglin/swapswap/domain/member/contorller/MemberController.java
+++ b/src/main/java/piglin/swapswap/domain/member/contorller/MemberController.java
@@ -179,7 +179,7 @@ public class MemberController {
             Model model
     ) {
 
-        PostListResponseDto responseDtoList = postService.getMyPostList(member,
+        PostListResponseDto responseDtoList = postService.getPostListByMember(member,
                 cursorTime);
 
         model.addAttribute("postListResponseDto", responseDtoList);
@@ -196,6 +196,15 @@ public class MemberController {
         return "member/otherMemberInfo";
     }
 
+    @GetMapping("/members/{memberId}/posts/more")
+    public String getOtherMemberInfoMore(@PathVariable Long memberId, Model model, @RequestParam(required = false) LocalDateTime cursorTime) {
+
+        model.addAttribute("postListResponseDto", memberService.getOtherMemberInfoMore(memberId,
+                cursorTime));
+
+        return "post/postListFragment";
+    }
+
     @GetMapping("/members/posts/more")
     public String getMyPostListMore(
             @AuthMember Member member,
@@ -203,7 +212,7 @@ public class MemberController {
             Model model
     ) {
 
-        PostListResponseDto responseDtoList = postService.getMyPostList(member,
+        PostListResponseDto responseDtoList = postService.getPostListByMember(member,
                 cursorTime);
 
         model.addAttribute("postListResponseDto", responseDtoList);

--- a/src/main/java/piglin/swapswap/domain/member/dto/OtherMemberInfoDto.java
+++ b/src/main/java/piglin/swapswap/domain/member/dto/OtherMemberInfoDto.java
@@ -6,6 +6,8 @@ import piglin.swapswap.domain.post.dto.response.PostListResponseDto;
 
 @Builder
 public record OtherMemberInfoDto(
+        Long memberId,
+
         String nickname,
 
         LocalDateTime createdTime,

--- a/src/main/java/piglin/swapswap/domain/member/mapper/MemberMapper.java
+++ b/src/main/java/piglin/swapswap/domain/member/mapper/MemberMapper.java
@@ -1,6 +1,7 @@
 package piglin.swapswap.domain.member.mapper;
 
 import java.time.LocalDateTime;
+import javax.sound.midi.MetaMessage;
 import piglin.swapswap.domain.member.constant.MemberRole;
 import piglin.swapswap.domain.member.dto.OtherMemberInfoDto;
 import piglin.swapswap.domain.member.dto.SocialUserInfo;
@@ -21,12 +22,13 @@ public class MemberMapper {
                 .build();
     }
 
-    public static OtherMemberInfoDto createOtherMemberInfoDto(String nickname,
-            LocalDateTime createdTime, PostListResponseDto postList) {
+    public static OtherMemberInfoDto createOtherMemberInfoDto(Member member,
+            PostListResponseDto postList) {
 
         return OtherMemberInfoDto.builder()
-                .nickname(nickname)
-                .createdTime(createdTime)
+                .memberId(member.getId())
+                .nickname(member.getNickname())
+                .createdTime(member.getCreatedTime())
                 .postList(postList)
                 .build();
     }

--- a/src/main/java/piglin/swapswap/domain/member/service/MemberService.java
+++ b/src/main/java/piglin/swapswap/domain/member/service/MemberService.java
@@ -5,6 +5,7 @@ import java.util.List;
 import piglin.swapswap.domain.member.dto.MemberNicknameDto;
 import piglin.swapswap.domain.member.dto.OtherMemberInfoDto;
 import piglin.swapswap.domain.member.entity.Member;
+import piglin.swapswap.domain.post.dto.response.PostListResponseDto;
 
 public interface MemberService {
 
@@ -23,4 +24,6 @@ public interface MemberService {
     List<Member> getMembers(List<Long> memberIds);
 
     OtherMemberInfoDto getOtherMemberInfo(Long memberId, LocalDateTime cursorTime);
+
+    PostListResponseDto getOtherMemberInfoMore(Long memberId, LocalDateTime cursorTime);
 }

--- a/src/main/java/piglin/swapswap/domain/member/service/MemberServiceImplV1.java
+++ b/src/main/java/piglin/swapswap/domain/member/service/MemberServiceImplV1.java
@@ -16,6 +16,7 @@ import piglin.swapswap.domain.membercoupon.service.MemberCouponService;
 import piglin.swapswap.domain.notification.service.NotificationService;
 import piglin.swapswap.domain.post.dto.response.PostListResponseDto;
 import piglin.swapswap.domain.post.entity.Post;
+import piglin.swapswap.domain.post.mapper.PostMapper;
 import piglin.swapswap.domain.post.service.PostService;
 import piglin.swapswap.domain.wallet.entity.Wallet;
 import piglin.swapswap.domain.wallethistory.service.WalletHistoryService;
@@ -129,12 +130,20 @@ public class MemberServiceImplV1 implements MemberService {
 
     @Override
     public OtherMemberInfoDto getOtherMemberInfo(Long memberId, LocalDateTime cursorTime) {
-        Member member = getMember(memberId);
-        PostListResponseDto responseDtoList = postService.getMyPostList(member, cursorTime);
 
-        return MemberMapper.createOtherMemberInfoDto(member.getNickname(), member.getCreatedTime(),
+        Member member = getMember(memberId);
+        PostListResponseDto responseDtoList = postService.getPostListByMember(member, cursorTime);
+
+        return MemberMapper.createOtherMemberInfoDto(member,
                 responseDtoList);
     }
 
+
+    public PostListResponseDto getOtherMemberInfoMore(Long memberId, LocalDateTime cursorTime) {
+
+        Member member = getMember(memberId);
+
+        return postService.getPostListByMember(member, cursorTime);
+    }
 
 }

--- a/src/main/java/piglin/swapswap/domain/post/mapper/PostMapper.java
+++ b/src/main/java/piglin/swapswap/domain/post/mapper/PostMapper.java
@@ -7,6 +7,8 @@ import piglin.swapswap.domain.deal.constant.DealStatus;
 import piglin.swapswap.domain.member.entity.Member;
 import piglin.swapswap.domain.post.dto.request.PostCreateRequestDto;
 import piglin.swapswap.domain.post.dto.request.PostUpdateRequestDto;
+import piglin.swapswap.domain.post.dto.response.PostListDetailResponseDto;
+import piglin.swapswap.domain.post.dto.response.PostListResponseDto;
 import piglin.swapswap.domain.post.dto.response.PostSimpleResponseDto;
 import piglin.swapswap.domain.post.entity.Post;
 
@@ -46,12 +48,15 @@ public class PostMapper {
                 .toList();
     }
 
-    public static PostSimpleResponseDto getPostSimpleInfoListByPost(Post post) {
+    public static PostListResponseDto createPostListResponseDtoWithIsLast(
+            List<PostListDetailResponseDto> postList) {
 
-        return PostSimpleResponseDto.builder()
-                        .postId(post.getId())
-                        .postTitle(post.getTitle())
-                        .imageUrl(post.getImageUrl().get(0).toString())
-                        .build();
+        boolean isLast = false;
+
+        if (postList.isEmpty()) {
+            isLast = true;
+        }
+
+        return new PostListResponseDto(postList, isLast);
     }
 }

--- a/src/main/java/piglin/swapswap/domain/post/service/PostService.java
+++ b/src/main/java/piglin/swapswap/domain/post/service/PostService.java
@@ -89,12 +89,12 @@ public interface PostService {
     void upPost(Long postId, Member member);
 
     /**
-     * 내 게시글 목록 조회 기능입니다.
-     * @param member 자신의 게시글 목록을 불러오기 위한 UserDetails 에서 받아온 매개변수입니다.
+     * 멤버 게시글 목록 조회 기능입니다.
+     * @param member 자신의 게시글 목록을 불러오기 위한 매개변수입니다.
      * @param cursorTime 커서 기반 페이지네이션을 위해 받는 커서입니다.
      * @return PostListResponseDto 를 반환하여 Model 로 화면을 그립니다.
      */
-    PostListResponseDto getMyPostList(Member member, LocalDateTime cursorTime);
+    PostListResponseDto getPostListByMember(Member member, LocalDateTime cursorTime);
 
     /**
      * 내 게시글 찜 목록 조회 기능입니다.

--- a/src/main/java/piglin/swapswap/domain/post/service/PostServiceImplV1.java
+++ b/src/main/java/piglin/swapswap/domain/post/service/PostServiceImplV1.java
@@ -80,7 +80,7 @@ public class PostServiceImplV1 implements PostService {
         List<PostListDetailResponseDto> postList = postRepository.findPostListWithFavoriteByCursor(
                 member, cursorTime);
 
-        return createPostListResponseDtoWithIsLast(postList);
+        return PostMapper.createPostListResponseDtoWithIsLast(postList);
     }
 
     @Override
@@ -153,7 +153,7 @@ public class PostServiceImplV1 implements PostService {
         List<PostListDetailResponseDto> postList = postRepository.searchPostListWithFavorite(
                 titleCond, categoryCond, cityCond, member, cursorTime);
 
-        return createPostListResponseDtoWithIsLast(postList);
+        return PostMapper.createPostListResponseDtoWithIsLast(postList);
     }
 
     @Override
@@ -182,7 +182,7 @@ public class PostServiceImplV1 implements PostService {
         List<PostListDetailResponseDto> postList = postRepository.findAllMyFavoritePost(
                 member, cursorTime);
 
-        return createPostListResponseDtoWithIsLast(postList);
+        return PostMapper.createPostListResponseDtoWithIsLast(postList);
     }
 
     @Override
@@ -192,12 +192,12 @@ public class PostServiceImplV1 implements PostService {
     }
 
     @Override
-    public PostListResponseDto getMyPostList(Member member, LocalDateTime cursorTime) {
+    public PostListResponseDto getPostListByMember(Member member, LocalDateTime cursorTime) {
 
         List<PostListDetailResponseDto> postList = postRepository.findAllMyPostList(member,
                 cursorTime);
 
-        return createPostListResponseDtoWithIsLast(postList);
+        return PostMapper.createPostListResponseDtoWithIsLast(postList);
     }
 
     private void checkPostDealStatus(Post post) {
@@ -267,18 +267,6 @@ public class PostServiceImplV1 implements PostService {
         if (responseDto.author() == null) {
             throw new BusinessException(ErrorCode.NOT_FOUND_POST_EXCEPTION);
         }
-    }
-
-    private PostListResponseDto createPostListResponseDtoWithIsLast(
-            List<PostListDetailResponseDto> postList) {
-
-        boolean isLast = false;
-
-        if (postList.isEmpty()) {
-            isLast = true;
-        }
-
-        return new PostListResponseDto(postList, isLast);
     }
 
     @Override

--- a/src/main/resources/templates/member/otherMemberInfo.html
+++ b/src/main/resources/templates/member/otherMemberInfo.html
@@ -66,6 +66,7 @@
   <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
   <script th:inline="javascript">
 
+    const memberId = [[${otherMemberInfo.memberId}]]
     let isLast = [[${otherMemberInfo.postList.isLast}]];
     let isLoading = false;
     let lastModifiedTime = null; // 마지막 게시물 수정 시간 초기화
@@ -105,7 +106,7 @@
 
     function loadMorePosts() {
       isLoading = true;
-      let url = '/members/posts/more?cursorTime=' + lastModifiedTime;
+      let url = '/members/'+ memberId +'/posts/more?cursorTime=' + lastModifiedTime;
 
       if(!isLast) {
 
@@ -150,6 +151,7 @@
     }
 
     function toggleFavorite(postId) {
+      console.log(postId)
       $.ajax({
         url: '/posts/' + postId + '/favorite',
         type: 'PATCH',


### PR DESCRIPTION
## 📝 개요
- 멤버 프로필 조회 후 게시글 더 불러올 시 다른 게시글이 불러오는 오류가 있었습니다.
<br>

## 👨‍💻 작업 내용
- 멤버 프로필 게시글 조회 다른 멤버 게시글 불러오는 문제 해결
<br>

## 🙇🏻‍♂️ 리뷰어에게
- 현재 이 기능에서 게시글 찜 확인을 param에 들어간 memberId 기준으로 조회해서 제대로 확인이 안되는 오류가 있습니다.
- 그 부분 수정하고 추가로 올리겠습니다
<br>
