### PR TITLE
fix: 메인페이지 카테고리 및 도시 선택 시 302 오류 해결

### DIFF
--- a/src/main/java/piglin/swapswap/domain/post/service/PostServiceImplV1.java
+++ b/src/main/java/piglin/swapswap/domain/post/service/PostServiceImplV1.java
@@ -140,7 +140,11 @@ public class PostServiceImplV1 implements PostService {
 
         Category categoryCond = null;
         City cityCond = null;
-        String titleCond = title.replaceAll(" ", "");
+        String titleCond = null;
+
+        if (title != null) {
+           titleCond = title.replaceAll(" ", "");
+        }
 
         if (category != null) {
             categoryCond = Enum.valueOf(Category.class, category);


### PR DESCRIPTION
## 📝 개요
- [#282 ]
<br>

## 👨‍💻 작업 내용
- 파람으로 들어온 title replace 하는 부분에서 NullPointException 뜨는 것으로 확인
- 해당 부분 null 이 아닐때 컨디션 설정하는 것으로 바꿨습니다.
<br>

## 🙇🏻‍♂️ 리뷰어에게
- 허허... 이 실수를 이제야 발견했네요
<br>
